### PR TITLE
Up XenVBD to build #6

### DIFF
--- a/manifestspecific.py
+++ b/manifestspecific.py
@@ -34,7 +34,7 @@ build_tar_source_files = {
         "xenvif" : "http://xenvif-build.uk.xensource.com:8080/job/XENVIF.git/4/artifact/xenvif.tar",
         "xennet" : "http://xennet-build.uk.xensource.com:8080/job/XENNET.git/4/artifact/xennet.tar",
         "xeniface" : "http://xeniface-build.uk.xensource.com:8080/job/Xeniface.git/3/artifact/xeniface.tar",
-        "xenvbd" : "http://xenvbd-build.uk.xensource.com:8080/job/XENVBD.git/5/artifact/xenvbd.tar",
+        "xenvbd" : "http://xenvbd-build.uk.xensource.com:8080/job/XENVBD.git/6/artifact/xenvbd.tar",
         "xenguestagent" : "http://xeniface-build.uk.xensource.com:8080/job/guest%20agent.git/29/artifact/xenguestagent.tar",
         "xenvss" : "http://xenvbd-build.uk.xensource.com:8080/job/XENVSS.git/6/artifact/xenvss.tar",
         } 


### PR DESCRIPTION
Change the minor version number to ensure XenVbd is installed in upgrade
situations

Signed-off-by: Ben Chalmers Ben.Chalmers@citrix.com
