### PR TITLE
[CP-4869] Check for WoW64 being turned off before installing 

### DIFF
--- a/src/installwizard/InstallWizard/InstallService.cs
+++ b/src/installwizard/InstallWizard/InstallService.cs
@@ -192,6 +192,13 @@ namespace InstallWizard
                 prog["installscore"] = new int[]{300,0};
                 prog["tempscore"] = new int[] { 0, 0 };
                 InstallState.MaxProgress = prog["installscore"][0];
+
+                if (InstallService.isWOW64())
+                {
+                    Trace.WriteLine("Install failed");
+                    InstallState.Fail("PV Tools cannot be installed on systems where .Net applications are forced to run under WoW64\n\nSet HKEY_LOCAL_MACHINE\\Software\\Microsoft\\.NetFramework\\Enable64Bit to 1 and attempt the install again.");
+                }
+
                 while ((!InstallState.Failed) && (InstallState.RebootCount > 0) && (!InstallState.Done))
                 {
                     InstallState.Unchanged = true;


### PR DESCRIPTION
This avoids an error case which has cropped up a few times in support calls and is which is difficult to track down the cause of, where things work unusually because WoW64 is redirecting system paths which (being designed for AnyCPU we don't expect)

Signed-off-by: Ben Chalmers Ben.Chalmers@citrix.com
