### PR TITLE
[CA-112773] Retry registering assembly with WMI

### DIFF
--- a/src/installwizard/InstallWizard/InstallService.cs
+++ b/src/installwizard/InstallWizard/InstallService.cs
@@ -140,13 +140,13 @@ namespace InstallWizard
                     {
                         Trace.WriteLine("Waiting for WMI to initialise");
                         Thread.Sleep(500);
-                        registertimeout += 500; ;
+                        registertimeout += 500;
                     }
                     catch (Exception e)
                     {
                         Trace.WriteLine("WMI initialisation not finished ("+e.ToString()+")");
                         Thread.Sleep(500);
-                        registertimeout+=500;
+                        registertimeout += 500;
                     }
                 }
                 if (!wmiregistered)


### PR DESCRIPTION
To avoid issues at start of day where WMI is not fully initialised when the
installer starts, we retry for up to 30 seconds in the event of any
failures.  If unsuccessful we now cause an installer failure rather than
entering an inescapable loop.

Signed-off-by: Ben Chalmers Ben.Chalmers@citrix.com
