### PR TITLE
[CP-6265] Sign all files in installer build

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,13 @@ Then use the following commands
     cd win-installer
     .\build.py --local <build output directory>
 
+To sign the drivers with a certificate installed on the build machine, the 
+following additional arguments can be placed after the build output directory 
+in the .\build.py command
+
+    --sign <certificate name> 
+        Sign with the best certificate matching <certificate name>
+    
+    --addcert <certificate file> 
+        Add an aditional <certificate file> to the signature block
 


### PR DESCRIPTION
Allowing us to make code signing optional

We do not sign cat files when all drivers are marked as being WHQL signed
as this prevents us overwriting the MS signature.

Signed-off-by: Ben Chalmers Ben.Chalmers@citrix.com
