### PR TITLE
XenVif #15 & XenNet #7

### DIFF
--- a/manifestspecific.py
+++ b/manifestspecific.py
@@ -30,8 +30,8 @@
 
 build_tar_source_files = {
         "xenbus" : "http://xenbus-build.uk.xensource.com:8080/job/XENBUS.git/13/artifact/xenbus.tar",
-        "xenvif" : "http://xenvif-build.uk.xensource.com:8080/job/XENVIF.git/14/artifact/xenvif.tar",
-        "xennet" : "http://xennet-build.uk.xensource.com:8080/job/XENNET.git/6/artifact/xennet.tar",
+        "xenvif" : "http://xenvif-build.uk.xensource.com:8080/job/XENVIF.git/15/artifact/xenvif.tar",
+        "xennet" : "http://xennet-build.uk.xensource.com:8080/job/XENNET.git/7/artifact/xennet.tar",
         "xeniface" : "http://xeniface-build.uk.xensource.com:8080/job/XENIFACE.git/5/artifact/xeniface.tar",
         "xenvbd" : "http://xenvbd-build.uk.xensource.com:8080/job/XENVBD.git/7/artifact/xenvbd.tar",
         "xenguestagent" : "http://xeniface-build.uk.xensource.com:8080/job/guest%20agent.git/33/artifact/xenguestagent.tar",


### PR DESCRIPTION
XenVif #15

Changes
Fix formatting
Re-work checksum code slightly to match reference code
Add some more assertions concerning checksums and large packets.
Two small refinements:
Use split RX/TX event channels if the backend supports them.

XenNet #7

Fix crash in co-installer
Update to latest VIF interface
