### PR TITLE
Add XenVbd 7.1.0.8

### DIFF
--- a/manifestspecific.py
+++ b/manifestspecific.py
@@ -33,7 +33,7 @@ build_tar_source_files = {
         "xenvif" : "http://xenvif-build.uk.xensource.com:8080/job/XENVIF.git/16/artifact/xenvif.tar",
         "xennet" : "http://xennet-build.uk.xensource.com:8080/job/XENNET.git/7/artifact/xennet.tar",
         "xeniface" : "http://xeniface-build.uk.xensource.com:8080/job/XENIFACE.git/5/artifact/xeniface.tar",
-        "xenvbd" : "http://xenvbd-build.uk.xensource.com:8080/job/XENVBD.git/7/artifact/xenvbd.tar",
+        "xenvbd" : "http://xenvbd-build.uk.xensource.com:8080/job/XENVBD.git/8/artifact/xenvbd.tar",
         "xenguestagent" : "http://xeniface-build.uk.xensource.com:8080/job/guest%20agent.git/33/artifact/xenguestagent.tar",
         "xenvss" : "http://xenvbd-build.uk.xensource.com:8080/job/XENVSS.git/6/artifact/xenvss.tar",
         } 


### PR DESCRIPTION
Use grant v1 for XENCRSH
Grant version cannot be changed during the lifetime of a domain.

Signed-off-by: Owen Smith owen.smith@citrix.com
