### PR TITLE
Up xeniface to #8

### DIFF
--- a/manifestspecific.py
+++ b/manifestspecific.py
@@ -32,7 +32,7 @@ build_tar_source_files = {
         "xenbus" : "http://xenbus-build.uk.xensource.com:8080/job/XENBUS.git/13/artifact/xenbus.tar",
         "xenvif" : "http://xenvif-build.uk.xensource.com:8080/job/XENVIF.git/20/artifact/xenvif.tar",
         "xennet" : "http://xennet-build.uk.xensource.com:8080/job/XENNET.git/9/artifact/xennet.tar",
-        "xeniface" : "http://xeniface-build.uk.xensource.com:8080/job/XENIFACE.git/7/artifact/xeniface.tar",
+        "xeniface" : "http://xeniface-build.uk.xensource.com:8080/job/XENIFACE.git/8/artifact/xeniface.tar",
         "xenvbd" : "http://xenvbd-build.uk.xensource.com:8080/job/XENVBD.git/8/artifact/xenvbd.tar",
         "xenguestagent" : "http://xeniface-build.uk.xensource.com:8080/job/guest%20agent.git/33/artifact/xenguestagent.tar",
         "xenvss" : "http://xenvbd-build.uk.xensource.com:8080/job/XENVSS.git/6/artifact/xenvss.tar",


### PR DESCRIPTION
Changes
[CA-119964] Add (excessive) event logging to id potential WMI failures
[ca-119964] Store LiteAgent symbols in xeniface tarfile
[CA-119964] Do not fail when WMI Remove does not provide a respose object

Signed-off-by: Ben Chalmers Ben.Chalmers@citrix.com
