### PR TITLE
[CP-7377] [CP-7376] Add HOSTTIME=utc option to installers

### DIFF
--- a/src/drivers/citrixxendrivers.wxs
+++ b/src/drivers/citrixxendrivers.wxs
@@ -88,9 +88,48 @@
     </Upgrade>
     <Property Id='FORCEINSTALL' Value='0'/>
     <Property Id='ARPSYSTEMCOMPONENT' Value='0'/>
+
+    <Property Id='HOSTTIME'>
+        <RegistrySearch Id='RememberHostTime'
+                        Root='HKLM'
+                        Key='SOFTWARE\Citrix\XenTools'
+                        Name='HostTime'
+                        Type='raw' 
+                        Win64='no'/>
+    </Property>
+    <Property Id='HOSTTIME64'>
+        <RegistrySearch Id='RememberHostTime64'
+                        Root='HKLM'
+                        Key='SOFTWARE\Citrix\XenTools'
+                        Name='HostTime'
+                        Type='raw' 
+                        Win64='yes'/>
+    </Property>
+
+    <CustomAction Id="SaveCmdLineHosttime"
+                  Property="CMDLINE_HOSTTIME"
+                  Value="[HOSTTIME]"
+                  Execute="firstSequence" />
+    <CustomAction Id="SetFromCmdLineHosttime"
+                  Property="HOSTTIME"
+                  Value="[CMDLINE_HOSTTIME]"
+                  Execute="firstSequence" />
+    <CustomAction Id="SetFromHosttime64"
+                  Property="HOSTTIME"
+                  Value="[HOSTTIME64]"
+                  Execute="firstSequence" />
+
+
     <Icon Id="icon.ico" SourceFile="$(var.Bitmaps)\xen.ico"/>
     <Property Id="ARPPRODUCTICON" Value="icon.ico" />
     <InstallExecuteSequence>
+        <Custom Action="SaveCmdLineHosttime" Before="AppSearch"/>
+        <Custom Action="SetFromHosttime64" After="AppSearch">
+            ((NOT HOSTTIME64="") AND (NOT CMDLINE_HOSTTIME))
+        </Custom>
+        <Custom Action="SetFromCmdLineHosttime" After="AppSearch">
+            CMDLINE_HOSTTIME
+        </Custom>
         <RemoveExistingProducts After="InstallValidate"/>
     </InstallExecuteSequence>
         
@@ -121,11 +160,34 @@
                     </Directory>
                 </Directory>
             </Directory>
-        <?endif?>
+            <?endif?>
+            <Component Id='RegEntry' Guid='*'>
+                <RegistryKey Root='HKLM'
+                    Key='Software\Citrix\XenTools'
+                    Action='createAndRemoveOnUninstall'>
+                    <RegistryValue Type='string' Name='HostTime' Value='[HOSTTIME]' />
+                </RegistryKey>
+            </Component>
+            <Component Id='RegEntry32' Guid='3a428079-00d8-4c55-b314-321e757ff988' Win64='no'>
+                <RegistryKey Root='HKLM'
+                    Key='Software\Citrix\XenTools'
+                    Action='createAndRemoveOnUninstall'>
+                    <RegistryValue Type='string' Name='HostTime' Value='[HOSTTIME]' />
+                </RegistryKey>
+            </Component>
     </Directory>
     <Feature Id='Complete' Level='1'>
-      <MergeRef Id='Drivers' />
+        <MergeRef Id='Drivers' />
+        <ComponentRef Id='RegEntry'/>
+        <?if $(sys.BUILDARCH)=x64 ?>
+            <ComponentRef Id='RegEntry32'/>
+        <?endif ?>
     </Feature>
+    <?if $(sys.BUILDARCH)=x86 ?>
+        <Feature Id="NotUsed" Level='0'>
+            <ComponentRef Id='RegEntry32'/>
+        </Feature>
+    <?endif ?>
   </Product>
 
 

--- a/src/installwizard/installwizard.wxs
+++ b/src/installwizard/installwizard.wxs
@@ -162,6 +162,10 @@
 
 
         <InstallUISequence>
+            <Custom Action="SaveCmdLineHosttime" Before="AppSearch" />
+            <Custom Action="SetFromCmdLineHosttime" After="AppSearch">
+                CMDLINE_HOSTTIME
+            </Custom>            
             <Show Dialog="MyExitDialog" OnExit="success" />
         </InstallUISequence>
         <AdminUISequence>
@@ -191,6 +195,25 @@
                         OnlyDetect='yes'
                         Property='UPGRADINGNEWERVERSION' />
     </Upgrade>
+
+    <Property Id='HOSTTIME'>
+        <RegistrySearch Id='RememberHostTime'
+                        Root='HKLM'
+                        Key='SOFTWARE\Citrix\XenTools'
+                        Name='HostTime'
+                        Type='raw' />
+    </Property>
+
+    <CustomAction Id="SaveCmdLineHosttime"
+                  Property="CMDLINE_HOSTTIME"
+                  Value="[HOSTTIME]"
+                  Execute="firstSequence" />
+    <CustomAction Id="SetFromCmdLineHosttime"
+                  Property="HOSTTIME"
+                  Value="[CMDLINE_HOSTTIME]"
+                  Execute="firstSequence" />
+
+
 
     <Property Id='FORCEINSTALL' Value='0'/>
 
@@ -345,6 +368,13 @@
                     <RegistryValue Type='string' Name='UIMode' Value='Passive' />
                 </RegistryKey> 
             </Component>
+            <Component Id="HostTime" Guid='*'>
+                <RegistryValue Root='HKLM'
+                    Key='Software\Citrix\XenTools'
+                    Name='HostTime'
+                    Value='[HOSTTIME]'
+                    Type='string'/>
+            </Component>
     </Directory>
     <Feature Id='Complete' Level='1'>
         <Condition Level='0'>
@@ -362,6 +392,7 @@
         <ComponentRef Id='Msis' />
         <ComponentRef Id='LegacyInstaller' />
         <ComponentRef Id='InstallStatus' />
+        <ComponentRef Id='HostTime' />
     </Feature>
     
     <Feature Id="NoReboot" Level="0">
@@ -394,6 +425,7 @@
         <Condition Level='1'>
             <![CDATA[(VersionNT<600)]]>
         </Condition>
+        <ComponentRef Id='HostTime' />
         <ComponentRef Id='LegacyInstaller' />
         <ComponentRef Id='InstallGui'/>
         <ComponentRef Id='InstallStatus' />
@@ -413,6 +445,10 @@
     <CustomAction Id='LaunchLegacy' FileKey="LegacyExe" Impersonate='yes' ExeCommand='[LaunchLegacy]' Return="asyncWait" Execute="deferred" />
 
     <InstallExecuteSequence>
+        <Custom Action="SaveCmdLineHosttime" Before="AppSearch" />
+        <Custom Action="SetFromCmdLineHosttime" After="AppSearch">
+            CMDLINE_HOSTTIME
+        </Custom>
         <Custom Action='InstallGui' Before="LegacySilent" >
             <![CDATA[NOT Installed]]>
         </Custom>


### PR DESCRIPTION
Added to installwizard.msi and citrixxendrivers*.msi

use argument HOSTTIME=utc for UTC hosttime,
or HOSTTIME=local for the default (treating xentime as local clock)

No hosttime argument will use whatever was previously set (and local
if nothing was previously set)

Signed-off-by: Ben Chalmers Ben.Chalmers@citrix.com
