### PR TITLE
[CA-127357] Fix upgrade from XS 5.5 tools to standard tools

### DIFF
--- a/src/installwizard/InstallWizard/InstallService.cs
+++ b/src/installwizard/InstallWizard/InstallService.cs
@@ -522,7 +522,12 @@ namespace InstallWizard
                             // lifetime of the uninstall.exe process.  Since we don't want to reboot
                             // while it (or its unattached children) are still running, we rely on
                             // the NSIS uninstaller to perform its own reboot, when it is done.
-                            if (InstallerNSIS.installed())
+                            //
+                            // We want to update George or earlier installers, as they don't
+                            // uninstall silently
+                            if (InstallerNSIS.installed() && 
+                                ((InstallerNSIS.majorVersion()>5 ) || 
+                                 ((InstallerNSIS.majorVersion()==5) && (InstallerNSIS.minorVersion()>5))))
                             {
                                 InstallerNSIS.uninstall();
                             }

--- a/src/installwizard/InstallWizard/Support.cs
+++ b/src/installwizard/InstallWizard/Support.cs
@@ -1423,7 +1423,36 @@ namespace InstallWizard
             return res;
 
         }
-   
+
+        public int majorVersion()
+        {
+            int res;
+            if (InstallService.is64BitOS() && (!InstallService.isWOW64()))
+            {
+                res = (int)Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Citrix\\XenTools", "MajorVersion", "");
+            }
+            else
+            {
+                res = (int)Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\Citrix\\XenTools", "MajorVersion", "");
+            }
+            return res;
+        }
+
+        public int minorVersion()
+        {
+            int res;
+            if (InstallService.is64BitOS() && (!InstallService.isWOW64()))
+            {
+                res = (int)Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Citrix\\XenTools", "MinorVersion", "");
+            }
+            else
+            {
+                res = (int)Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\Citrix\\XenTools", "MinorVersion", "");
+            }
+            return res;
+        }
+
+
         public bool nsisPartiallyInstalled()
         {
             try
@@ -1737,6 +1766,7 @@ namespace InstallWizard
                 if ((pciDeviceName != "XenServer PV Bus") // XenServer Standard drivers
                     && (pciDeviceName != "Citrix PV Bus") // Citrix XenServer Standard Drivers
                     && (pciDeviceName != "Citrix PV SCSI Host Adapter") // Legacy Drivers
+                    && (pciDeviceName != "Citrix XenServer PV SCSI Host Adapter") // 5.5 Legacy Drivers
                    ) 
                 {
                     return true;


### PR DESCRIPTION
5.5 (George) tools have a different driver name which we must
check for and accept

5.5 tools can require interaction on silent uninstalls, so we
have to upgrade to latest legacy tools and uninstall them instead

Signed-off-by: Ben Chalmers Ben.Chalmers@citrix.com
