### PR TITLE
XenNet #12 XenBus #15 XenIface #14

### DIFF
--- a/manifestspecific.py
+++ b/manifestspecific.py
@@ -29,10 +29,10 @@
 # SUCH DAMAGE.
 
 build_tar_source_files = {
-        "xenbus" : "http://xenbus-build.uk.xensource.com:8080/job/XENBUS.git/13/artifact/xenbus.tar",
+        "xenbus" : "http://xenbus-build.uk.xensource.com:8080/job/XENBUS.git/15/artifact/xenbus.tar",
         "xenvif" : "http://xenvif-build.uk.xensource.com:8080/job/XENVIF.git/24/artifact/xenvif.tar",
-        "xennet" : "http://xennet-build.uk.xensource.com:8080/job/XENNET.git/10/artifact/xennet.tar",
-        "xeniface" : "http://xeniface-build.uk.xensource.com:8080/job/XENIFACE.git/10/artifact/xeniface.tar",
+        "xennet" : "http://xennet-build.uk.xensource.com:8080/job/XENNET.git/12/artifact/xennet.tar",
+        "xeniface" : "http://xeniface-build.uk.xensource.com:8080/job/XENIFACE.git/14/artifact/xeniface.tar",
         "xenvbd" : "http://xenvbd-build.uk.xensource.com:8080/job/XENVBD.git/9/artifact/xenvbd.tar",
         "xenguestagent" : "http://xeniface-build.uk.xensource.com:8080/job/guest%20agent.git/34/artifact/xenguestagent.tar",
         "xenvss" : "http://xenvbd-build.uk.xensource.com:8080/job/XENVSS.git/7/artifact/xenvss.tar",


### PR DESCRIPTION
XenNet
Add SDV to the standard build
Fix several build warnings
Fix a double-free and add more logging in the co-installer

XenBus
Add an error check for an 'EQUOTA' response from xenstore and
Add option to use emulated boot disk

XenIface
Add SDV to the standard build
[CAR-1423] Port UTC hostime / timezone support to lite agent
[CP-7374] Bugfixes to lite agent UTC hosttime code
[CP-7391] Ensure new directories are created when copying release binaries too
[CP-7391] Ensure new directories are created when copying binaries

Signed-off-by: Ben Chalmers Ben.Chalmers@citrix.com
