### PR TITLE
XENVIF #29

### DIFF
--- a/manifestspecific.py
+++ b/manifestspecific.py
@@ -30,7 +30,7 @@
 
 build_tar_source_files = {
         "xenbus" : "http://xenbus-build.uk.xensource.com:8080/job/XENBUS.git/25/artifact/xenbus.tar",
-        "xenvif" : "http://xenvif-build.uk.xensource.com:8080/job/XENVIF.git/27/artifact/xenvif.tar",
+        "xenvif" : "http://xenvif-build.uk.xensource.com:8080/job/XENVIF.git/29/artifact/xenvif.tar",
         "xennet" : "http://xennet-build.uk.xensource.com:8080/job/XENNET.git/14/artifact/xennet.tar",
         "xeniface" : "http://xeniface-build.uk.xensource.com:8080/job/XENIFACE.git/14/artifact/xeniface.tar",
         "xenvbd" : "http://xenvbd-build.uk.xensource.com:8080/job/XENVBD.git/16/artifact/xenvbd.tar",


### PR DESCRIPTION
Remove erroneous #if 0s
Re-order refine because it vapourizes the SDV summary log

Signed-off-by: Ben Chalmers Ben.Chalmers@citrix.com
