### PR TITLE
XENBUS #28

### DIFF
--- a/manifestspecific.py
+++ b/manifestspecific.py
@@ -29,7 +29,7 @@
 # SUCH DAMAGE.
 
 build_tar_source_files = {
-        "xenbus" : "http://xenbus-build.uk.xensource.com:8080/job/XENBUS.git/26/artifact/xenbus.tar",
+        "xenbus" : "http://xenbus-build.uk.xensource.com:8080/job/XENBUS.git/28/artifact/xenbus.tar",
         "xenvif" : "http://xenvif-build.uk.xensource.com:8080/job/XENVIF.git/32/artifact/xenvif.tar",
         "xennet" : "http://xennet-build.uk.xensource.com:8080/job/XENNET.git/14/artifact/xennet.tar",
         "xeniface" : "http://xeniface-build.uk.xensource.com:8080/job/XENIFACE.git/14/artifact/xeniface.tar",


### PR DESCRIPTION
Add error path to RangeSetPop()
Fix bug in RangeSetGet()
Fix 'unreferenced parameter' warning checked builds
Better way to ignore assertions in free builds
Various fixes in improvements to the XEX.SYS System module

Signed-off-by: Ben Chalmers Ben.Chalmers@citrix.com
