### PR TITLE
XENBUS #30

### DIFF
--- a/manifestspecific.py
+++ b/manifestspecific.py
@@ -29,7 +29,7 @@
 # SUCH DAMAGE.
 
 build_tar_source_files = {
-        "xenbus" : "http://xenbus-build.uk.xensource.com:8080/job/XENBUS.git/29/artifact/xenbus.tar",
+        "xenbus" : "http://xenbus-build.uk.xensource.com:8080/job/XENBUS.git/30/artifact/xenbus.tar",
         "xenvif" : "http://xenvif-build.uk.xensource.com:8080/job/XENVIF.git/32/artifact/xenvif.tar",
         "xennet" : "http://xennet-build.uk.xensource.com:8080/job/XENNET.git/14/artifact/xennet.tar",
         "xeniface" : "http://xeniface-build.uk.xensource.com:8080/job/XENIFACE.git/14/artifact/xeniface.tar",


### PR DESCRIPTION
RangeSet fixes
- add spinlock to protect rangesets.
- add a Count value to check against empty condition in audit.
- use LONGLONG in ranges rather than ULONGLONG so that ranges can be
  invalidated by setting Start > End.

Signed-off-by: Ben Chalmers Ben.Chalmers@citrix.com
