### PR TITLE
[SCTX-1104] Windows PE Script registry entry changes

### DIFF
--- a/src/pescripts/ADK8.bat
+++ b/src/pescripts/ADK8.bat
@@ -25,10 +25,14 @@ rem Make the registry changes needed to set up filters and unplug
 rem the emulated devices
 
 reg load HKLM\pemount mountpe\Windows\System32\config\SYSTEM
-reg ADD HKLM\pemount\ControlSet001\Services\xenfilt\Parameters /v VBD /t REG_MULTI_SZ  /d 0\01\02\03
+reg ADD HKLM\pemount\ControlSet001\Services\xenbus\Parameters /v ActiveDevice /t REG_SZ /d "PCI\VEN_5853&DEV_0002&SUBSYS_00025853&REV_02"
+reg ADD HKLM\pemount\ControlSet001\Services\xenfilt /v WindowsPEMode /t REG_DWORD /d 1
+reg ADD HKLM\pemount\ControlSet001\Services\xenfilt\UNPLUG /v DISKS /t REG_MULTI_SZ /d xenvbd
+reg ADD HKLM\pemount\ControlSet001\Services\xenfilt\UNPLUG /v NICS /t REG_MULTI_SZ /d xenvif\0xennet
+reg ADD HKLM\pemount\ControlSet001\Services\xennet /v Count /t REG_DWORD /d 1
+reg ADD HKLM\pemount\ControlSet001\Services\xenvif /v Count /t REG_DWORD /d 1
+reg ADD HKLM\pemount\ControlSet001\Services\xenvbd /v Count /t REG_DWORD /d 1
 reg ADD HKLM\pemount\ControlSet001\Control\class\{4D36E96A-E325-11CE-BFC1-08002BE10318} /v UpperFilters /t REG_MULTI_SZ /d XENFILT
-reg ADD HKLM\pemount\ControlSet001\Services\xenfilt\Parameters /v VIF /t REG_MULTI_SZ /d 0\01\02\03\04\05\06\07
-reg ADD HKLM\pemount\ControlSet001\Services\xenfilt\Parameters /v UnplugClasses /t REG_MULTI_SZ  /d VBD\0VIF
 reg ADD HKLM\pemount\ControlSet001\Control\class\{4D36E97D-E325-11CE-BFC1-08002BE10318} /v UpperFilters /t REG_MULTI_SZ /d XENFILT
 reg unload HKLM\pemount
 

--- a/src/pescripts/AIK1.bat
+++ b/src/pescripts/AIK1.bat
@@ -25,10 +25,14 @@ rem Make the registry changes needed to set up filters and unplug
 rem the emulated devices
 
 reg load HKLM\pemount mountpe\Windows\System32\config\SYSTEM
-reg ADD HKLM\pemount\ControlSet001\Services\xenfilt\Parameters /v VBD /t REG_MULTI_SZ  /d 0\01\02\03
+reg ADD HKLM\pemount\ControlSet001\Services\xenbus\Parameters /v ActiveDevice /t REG_SZ /d "PCI\VEN_5853&DEV_0002&SUBSYS_00025853&REV_02"
+reg ADD HKLM\pemount\ControlSet001\Services\xenfilt /v WindowsPEMode /t REG_DWORD /d 1
+reg ADD HKLM\pemount\ControlSet001\Services\xenfilt\UNPLUG /v DISKS /t REG_MULTI_SZ /d xenvbd
+reg ADD HKLM\pemount\ControlSet001\Services\xenfilt\UNPLUG /v NICS /t REG_MULTI_SZ /d xenvif\0xennet
+reg ADD HKLM\pemount\ControlSet001\Services\xennet /v Count /t REG_DWORD /d 1
+reg ADD HKLM\pemount\ControlSet001\Services\xenvif /v Count /t REG_DWORD /d 1
+reg ADD HKLM\pemount\ControlSet001\Services\xenvbd /v Count /t REG_DWORD /d 1
 reg ADD HKLM\pemount\ControlSet001\Control\class\{4D36E96A-E325-11CE-BFC1-08002BE10318} /v UpperFilters /t REG_MULTI_SZ /d XENFILT
-reg ADD HKLM\pemount\ControlSet001\Services\xenfilt\Parameters /v VIF /t REG_MULTI_SZ /d 0\01\02\03\04\05\06\07
-reg ADD HKLM\pemount\ControlSet001\Services\xenfilt\Parameters /v UnplugClasses /t REG_MULTI_SZ  /d VBD\0VIF
 reg ADD HKLM\pemount\ControlSet001\Control\class\{4D36E97D-E325-11CE-BFC1-08002BE10318} /v UpperFilters /t REG_MULTI_SZ /d XENFILT
 reg unload HKLM\pemount
 

--- a/src/pescripts/AIK2.bat
+++ b/src/pescripts/AIK2.bat
@@ -25,13 +25,16 @@ rem Make the registry changes needed to set up filters and unplug
 rem the emulated devices
 
 reg load HKLM\pemount mountpe\Windows\System32\config\SYSTEM
-reg ADD HKLM\pemount\ControlSet001\Services\xenfilt\Parameters /v VBD /t REG_MULTI_SZ  /d 0\01\02\03
+reg ADD HKLM\pemount\ControlSet001\Services\xenbus\Parameters /v ActiveDevice /t REG_SZ /d "PCI\VEN_5853&DEV_0002&SUBSYS_00025853&REV_02"
+reg ADD HKLM\pemount\ControlSet001\Services\xenfilt /v WindowsPEMode /t REG_DWORD /d 1
+reg ADD HKLM\pemount\ControlSet001\Services\xenfilt\UNPLUG /v DISKS /t REG_MULTI_SZ /d xenvbd
+reg ADD HKLM\pemount\ControlSet001\Services\xenfilt\UNPLUG /v NICS /t REG_MULTI_SZ /d xenvif\0xennet
+reg ADD HKLM\pemount\ControlSet001\Services\xennet /v Count /t REG_DWORD /d 1
+reg ADD HKLM\pemount\ControlSet001\Services\xenvif /v Count /t REG_DWORD /d 1
+reg ADD HKLM\pemount\ControlSet001\Services\xenvbd /v Count /t REG_DWORD /d 1
 reg ADD HKLM\pemount\ControlSet001\Control\class\{4D36E96A-E325-11CE-BFC1-08002BE10318} /v UpperFilters /t REG_MULTI_SZ /d XENFILT
-reg ADD HKLM\pemount\ControlSet001\Services\xenfilt\Parameters /v VIF /t REG_MULTI_SZ /d 0\01\02\03\04\05\06\07
-reg ADD HKLM\pemount\ControlSet001\Services\xenfilt\Parameters /v UnplugClasses /t REG_MULTI_SZ  /d VBD\0VIF
 reg ADD HKLM\pemount\ControlSet001\Control\class\{4D36E97D-E325-11CE-BFC1-08002BE10318} /v UpperFilters /t REG_MULTI_SZ /d XENFILT
 reg unload HKLM\pemount
-
 rem Unmount the wim file, and commit the changes
 
 imagex /unmount /commit mountpe


### PR DESCRIPTION
Changes the registry entries in windows PE scripts to work with the
new XenFilt WindowsPEMode

Signed-off-by: Ben Chalmers Ben.Chalmers@citrix.com
