### PR TITLE
XENBUS 35, XENVIF 37

### DIFF
--- a/manifestspecific.py
+++ b/manifestspecific.py
@@ -29,8 +29,8 @@
 # SUCH DAMAGE.
 
 build_tar_source_files = {
-        "xenbus" : "http://xenbus-build.uk.xensource.com:8080/job/XENBUS.git/32/artifact/xenbus.tar",
-        "xenvif" : "http://xenvif-build.uk.xensource.com:8080/job/XENVIF.git/35/artifact/xenvif.tar",
+        "xenbus" : "http://xenbus-build.uk.xensource.com:8080/job/XENBUS.git/35/artifact/xenbus.tar",
+        "xenvif" : "http://xenvif-build.uk.xensource.com:8080/job/XENVIF.git/37/artifact/xenvif.tar",
         "xennet" : "http://xennet-build.uk.xensource.com:8080/job/XENNET.git/14/artifact/xennet.tar",
         "xeniface" : "http://xeniface-build.uk.xensource.com:8080/job/XENIFACE.git/14/artifact/xeniface.tar",
         "xenvbd" : "http://xenvbd-build.uk.xensource.com:8080/job/XENVBD.git/17/artifact/xenvbd.tar",


### PR DESCRIPTION
XENBUS
Re-try AuxKlibQueryModuleInformation() if buffer was too small

XENVIF
Re-try AuxKlibQueryModuleInformation() if buffer was too small

Signed-off-by: Ben Chalmers Ben.Chalmers@citrix.com
