### PR TITLE
xenvbd 27, xenbus 45, xenvif 43

### DIFF
--- a/manifestspecific.py
+++ b/manifestspecific.py
@@ -29,11 +29,11 @@
 # SUCH DAMAGE.
 
 build_tar_source_files = {
-        "xenbus" : "http://xenbus-build.uk.xensource.com:8080/job/XENBUS.git/43/artifact/xenbus.tar",
-        "xenvif" : "http://xenvif-build.uk.xensource.com:8080/job/XENVIF.git/41/artifact/xenvif.tar",
+        "xenbus" : "http://xenbus-build.uk.xensource.com:8080/job/XENBUS.git/45/artifact/xenbus.tar",
+        "xenvif" : "http://xenvif-build.uk.xensource.com:8080/job/XENVIF.git/43/artifact/xenvif.tar",
         "xennet" : "http://xennet-build.uk.xensource.com:8080/job/XENNET.git/14/artifact/xennet.tar",
         "xeniface" : "http://xeniface-build.uk.xensource.com:8080/job/XENIFACE.git/14/artifact/xeniface.tar",
-        "xenvbd" : "http://xenvbd-build.uk.xensource.com:8080/job/XENVBD.git/18/artifact/xenvbd.tar",
+        "xenvbd" : "http://xenvbd-build.uk.xensource.com:8080/job/XENVBD.git/27/artifact/xenvbd.tar",
         "xenguestagent" : "http://xeniface-build.uk.xensource.com:8080/job/guest%20agent.git/34/artifact/xenguestagent.tar",
         "xenvss" : "http://xenvbd-build.uk.xensource.com:8080/job/XENVSS.git/7/artifact/xenvss.tar",
         } 


### PR DESCRIPTION
xenvbd 27

Fix PdoReset by attempting to poll ring for up to 5 minutes before
bugchecking
SDV is picky about %d/%u printf format specifiers
Use new GNTTAB interface
Track current/maximum grant usage
Refactor: internalize request preparation functions into a single call
Always bounce SRBs via FreshSrbs queue
Move Lookaside functions to same part of pdo.c
Fold BlockRingPush into BlockRingSubmit
Submit all prepared requests then attempt to prepare the next SRB
Fix checked-only bugcheck (0xD1 due to IsOnList in buffer.c)
Fix SDV on xencrsh
Fix build by removing (redefinition) of MmGetPhysicalAddress
Add sdv build to build.py, include nosdv option to not run sdv
Fix SDV errors, completes SDV and DVL log run
Log BLKIF_OP_\* values when backend fails request
[CA-134598] Store the (partial) tag along with the XENVBD_REQUEST.

xenbus 45

Rename Pool\* to Cache*
Introduce the CACHE interface
Export CACHE interface to child drivers
Remove much code duplication involved in interface query
Modify GNTTAB interface to support caches

xenvif 43

Use new XENBUS CACHE interface rather than local pool code
Remove much code duplication
Use new GNTTAB interface

Signed-off-by: Ben Chalmers Ben.Chalmers@citrix.com
