### PR TITLE
XenVBD #38

### DIFF
--- a/manifestspecific.py
+++ b/manifestspecific.py
@@ -33,7 +33,7 @@ build_tar_source_files = {
         "xenvif" : "http://xenvif-build.uk.xensource.com:8080/job/XENVIF.git/44/artifact/xenvif.tar",
         "xennet" : "http://xennet-build.uk.xensource.com:8080/job/XENNET.git/14/artifact/xennet.tar",
         "xeniface" : "http://xeniface-build.uk.xensource.com:8080/job/XENIFACE.git/14/artifact/xeniface.tar",
-        "xenvbd" : "http://xenvbd-build.uk.xensource.com:8080/job/XENVBD.git/32/artifact/xenvbd.tar",
+        "xenvbd" : "http://xenvbd-build.uk.xensource.com:8080/job/XENVBD.git/38/artifact/xenvbd.tar",
         "xenguestagent" : "http://xeniface-build.uk.xensource.com:8080/job/guest%20agent.git/34/artifact/xenguestagent.tar",
         "xenvss" : "http://xenvbd-build.uk.xensource.com:8080/job/XENVSS.git/7/artifact/xenvss.tar",
         } 


### PR DESCRIPTION
Increase disk timeout during co-installer to a minimum of 120 seconds
Fix service key name

Signed-off-by: Ben Chalmers Ben.Chalmers@citrix.com
