### PR TITLE
XenVBD #40 (Jun 20, 2014 10:01:26 AM)

### DIFF
--- a/manifestspecific.py
+++ b/manifestspecific.py
@@ -33,7 +33,7 @@ build_tar_source_files = {
         "xenvif" : "http://xenvif-build.uk.xensource.com:8080/job/XENVIF.git/44/artifact/xenvif.tar",
         "xennet" : "http://xennet-build.uk.xensource.com:8080/job/XENNET.git/14/artifact/xennet.tar",
         "xeniface" : "http://xeniface-build.uk.xensource.com:8080/job/XENIFACE.git/14/artifact/xeniface.tar",
-        "xenvbd" : "http://xenvbd-build.uk.xensource.com:8080/job/XENVBD.git/38/artifact/xenvbd.tar",
+        "xenvbd" : "http://xenvbd-build.uk.xensource.com:8080/job/XENVBD.git/40/artifact/xenvbd.tar",
         "xenguestagent" : "http://xeniface-build.uk.xensource.com:8080/job/guest%20agent.git/34/artifact/xenguestagent.tar",
         "xenvss" : "http://xenvbd-build.uk.xensource.com:8080/job/XENVSS.git/7/artifact/xenvss.tar",
         } 


### PR DESCRIPTION
Force calling BlockRingPoll as DPC may not run.
Cleanup PreparedReqs before closing the ring
Add extra state to frontend transition to allow reset to cleanup

Signed-off-by: Ben Chalmers Ben.Chalmers@citrix.com
