### PR TITLE
XenVif #51 (Second attempt)

### DIFF
--- a/manifestspecific.py
+++ b/manifestspecific.py
@@ -33,7 +33,7 @@ localserver = r'\\camos.uk.xensource.com\build\windowsbuilds\WindowsBuilds'
 
 build_tar_source_files = {
        "xenbus" : r'standard-lcm\10\xenbus-7-2-0-47.tar',
-       "xenvif" : r'xenvif.git.whql\51\xenvif-7-2-0-48.tar',
+       "xenvif" : r'xenvif.git\51\xenvif.tar',
        "xennet" : r'standard-lcm\13\xennet-7-2-0-14.tar',
        "xeniface" : r'standard-lcm\12\xeniface-7-2-0-14.tar',
        "xenvbd" : r'standard-lcm\14\xenvbd-7-2-0-40.tar',
@@ -41,4 +41,4 @@ build_tar_source_files = {
        "xenvss" : r'standard-lcm\16\xenvss-7.tar',
 } 
 
-all_drivers_signed = True
+all_drivers_signed = False


### PR DESCRIPTION
Stop doing MIB table dumps under transitter ring lock
Limit MIB table dumps to at most once every 5 seconds
Add more tracing and limit the size of the address table
Promote xenvif.sys to be a boot start driver on network boot
Cope with unexpected initial backend states

Signed-off-by: Ben Chalmers Ben.Chalmers@citrix.com
