### PR TITLE
XenVif #52

### DIFF
--- a/manifestspecific.py
+++ b/manifestspecific.py
@@ -33,7 +33,7 @@ localserver = r'\\camos.uk.xensource.com\build\windowsbuilds\WindowsBuilds'
 
 build_tar_source_files = {
        "xenbus" : r'standard-lcm\10\xenbus-7-2-0-47.tar',
-       "xenvif" : r'xenvif.git\51\xenvif.tar',
+       "xenvif" : r'xenvif.git\52\xenvif.tar',
        "xennet" : r'standard-lcm\13\xennet-7-2-0-14.tar',
        "xeniface" : r'standard-lcm\12\xeniface-7-2-0-14.tar',
        "xenvbd" : r'standard-lcm\14\xenvbd-7-2-0-40.tar',


### PR DESCRIPTION
Kick data/updated after writing attr/ethX keys

For some reason best known to itself XAPI relies on us writing to
data/updated after modifying xenstore keys under attr/ethX to notice
that things have changed. Go figure.

Signed-off-by: Ben Chalmers Ben.Chalmers@citrix.com
