### PR TITLE
XenVif 7.2.0.52 (Whql)

### DIFF
--- a/manifestspecific.py
+++ b/manifestspecific.py
@@ -33,7 +33,7 @@ localserver = r'\\camos.uk.xensource.com\build\windowsbuilds\WindowsBuilds'
 
 build_tar_source_files = {
        "xenbus" : r'standard-lcm\10\xenbus-7-2-0-47.tar',
-       "xenvif" : r'xenvif.git\52\xenvif.tar',
+       "xenvif" : r'xenvif.git.whql\52\xenvif-7-2-0-52.tar',
        "xennet" : r'standard-lcm\13\xennet-7-2-0-14.tar',
        "xeniface" : r'xeniface.git\17\xeniface.tar',
        "xenvbd" : r'standard-lcm\14\xenvbd-7-2-0-40.tar',
@@ -41,4 +41,4 @@ build_tar_source_files = {
        "xenvss" : r'standard-lcm\16\xenvss-7.tar',
 } 
 
-all_drivers_signed = False
+all_drivers_signed = True


### PR DESCRIPTION
all_drivers_signed=True

```
Kick data/updated after writing attr/ethX keys

For some reason best known to itself XAPI relies on us writing to
data/updated after modifying xenstore keys under attr/ethX to notice
that things have changed. Go figure.
```

Signed-off-by: Owen Smith owen.smith@citrix.com
