### PR TITLE
[CA-147887] If we try to copy a reg key that doesn't exist, create it

### DIFF
--- a/src/netsetlib/registry.cpp
+++ b/src/netsetlib/registry.cpp
@@ -736,11 +736,15 @@ CopyValues(
         goto fail1;
     }
 
-    Error = RegOpenKeyEx(HKEY_LOCAL_MACHINE,
+    Error = RegCreateKeyEx(HKEY_LOCAL_MACHINE,
                          SourceKeyName,
                          0,
+						 NULL,
+						 REG_OPTION_NON_VOLATILE,
                          KEY_ALL_ACCESS,
-                         &SourceKey);
+						 NULL,
+                         &SourceKey,
+						 NULL);
     if (Error != ERROR_SUCCESS) {
         SetLastError(Error);
         goto fail2;


### PR DESCRIPTION
(Used as a workaround because xennet fails to complete its coinstaller
if it can't find all the netsettings keys it expects to copy)

Signed-off-by: Ben Chalmers Ben.Chalmers@citrix.com
