### PR TITLE
[CA-152000] Failed to enumerate values being deleted

### DIFF
--- a/src/netsetlib/registry.h
+++ b/src/netsetlib/registry.h
@@ -182,6 +182,8 @@ typedef HRESULT(*ITERATOR_CALLBACK)(ITERATOR_CALLBACK_DATA *, void*);
 
 typedef HRESULT(*SUBKEY_ITERATOR_CALLBACK)(SUBKEY_ITERATOR_CALLBACK_DATA *, void*);
 
+typedef BOOLEAN(*CONDITIONAL_CALLBACK)(ITERATOR_CALLBACK_DATA *, void*);
+
 extern HRESULT 
 RegistryDeleteIfMatchingNetLuid(
 	ITERATOR_CALLBACK_DATA	*iteratordata, 
@@ -192,6 +194,12 @@ extern HRESULT
 RegistryRestoreWithNewNetLuid(
 	ITERATOR_CALLBACK_DATA	*iteratordata, 
 	void					*externaldata
+);
+
+extern BOOLEAN
+RegistryIsMatchingNetLuid(
+    ITERATOR_CALLBACK_DATA  *iteratordata,
+    void                    *externaldata
 );
 
 extern HRESULT 
@@ -206,6 +214,13 @@ RegistryIterateOverKeySubKeys(
 	PTCHAR						KeyName, 
 	SUBKEY_ITERATOR_CALLBACK	callback, 
 	void						*data
+);
+
+extern HRESULT 
+RegistryDeleteValuesOnCondition(
+    PTCHAR                  KeyName,
+    CONDITIONAL_CALLBACK    callback, 
+    void                    *data
 );
 
 extern PTCHAR

--- a/src/netsetlib/restore.cpp
+++ b/src/netsetlib/restore.cpp
@@ -131,7 +131,7 @@ HRESULT restoreStaticNetworkConfiguration(DWORD deviceIndex, HKEY DestinationKey
 		RegCloseKey(CheckKey);
 
 		Log("IPV6 Static deletion required");
-		Error = RegistryIterateOverKeyValues(STATIC_IPV6_KEY, RegistryDeleteIfMatchingNetLuid, &restoreData.NetLuid);
+        Error = RegistryDeleteValuesOnCondition(STATIC_IPV6_KEY, RegistryIsMatchingNetLuid, &restoreData.NetLuid);
 		if (Error != ERROR_SUCCESS) {
 			Warning("Removing values failed");
 			goto fail3;


### PR DESCRIPTION
While enumerating over values, deleting a value invalidates the current
index. Implement a delete-if-condition is met function to delete values
during an enumeration of these values.

Signed-off-by: Owen Smith owen.smith@citrix.com
