### PR TITLE
[CP-10562] Moving to patchqueue based drivers

### DIFF
--- a/manifestspecific.py
+++ b/manifestspecific.py
@@ -32,11 +32,11 @@ secureserver = r'\\10.80.13.10\distfiles\distfiles\WindowsBuilds'
 localserver = r'\\camos.uk.xensource.com\build\windowsbuilds\WindowsBuilds'
 
 build_tar_source_files = {
-       "xenbus" : r'xenbus.git\50\xenbus.tar',
-       "xenvif" : r'xenvif.git.whql\56\xenvif-7-2-0-56.tar',
-       "xennet" : r'standard-lcm\13\xennet-7-2-0-14.tar',
-       "xeniface" : r'standard-lcm\12\xeniface-7-2-0-14.tar',
-       "xenvbd" : r'xenvbd.git\41\xenvbd.tar',
+       "xenbus" : r'xenbus-patchq.git\12\xenbus.tar',
+       "xenvif" : r'xenvif-patchq.git\5\xenvif.tar',
+       "xennet" : r'xennet-patchq.git\4\xennet.tar',
+       "xeniface" : r'xeniface-patchq.git\3\xeniface.tar',
+       "xenvbd" : r'xenvbd-patchq.git\9\xenvbd.tar',
        "xenguestagent" : r'xenguestagent.git\127\xenguestagent.tar',
        "xenvss" : r'standard-lcm\16\xenvss-7.tar',
 } 


### PR DESCRIPTION
This is the introduction of the 8.0 driver stream which
derive from the xen project and can be located at

http://xenbits.xen.org/gitweb/

Our base 8.0 drivers are
xenbus 12
xenvif 5
xennet 4
xeniface 3
xenvbd 9

Please make changes to these drivers, following the
process documented at

http://www.xenproject.org/developers/teams/windows-pv-drivers.html

We continue to use

xenguestagent 127
and
xenvss 16

Which derive from the XenServer github repositories, and continue
to follow a github pull-request based workflow

Signed-off-by: Ben Chalmers <Ben.Chalmers@citrix.com>