### PR TITLE
[CA-159586] Wait for all installs to finish before rebooting

### DIFF
--- a/src/installwizard/InstallWizard/InstallService.cs
+++ b/src/installwizard/InstallWizard/InstallService.cs
@@ -495,7 +495,10 @@ namespace InstallWizard
 
                     if ((!InstallState.RebootReady) && InstallState.RebootNow && InstallState.Unchanged)
                     {
+
                         // We are ready to reboot
+                        Trace.WriteLine("Is anything preventing us from shutting down?");
+                        setupapi.CMP_WaitNoPendingInstallEvents(0xffffffff);
                         Trace.WriteLine("Ready to reboot");
                         InstallState.Polling = false;
                         InstallState.RebootDesired = true;


### PR DESCRIPTION
Refactors setupapi functions to move them into a module of their own

Detects if a bus device's children are not available using CM_Get_DevNode_Status

Detects if all current installs have finished using CMP_WaitNoPendingInstallEvents

Clarified the 'servicesrunning' function

We no longer need to rely on reenumerating the bus to try to determine if all install events have finished