### PR TITLE
CP-12176 : Win10 Preview should only install on Windows 10

### DIFF
--- a/src/drivers/citrixxendrivers.wxs
+++ b/src/drivers/citrixxendrivers.wxs
@@ -58,13 +58,13 @@
     <?define CurrentMicroVersion = '$(var.BRANDING_MICRO_VERSION_STR)' ?>
     <?define CurrentBuildVersion = '$(var.BRANDING_BUILD_NR_STR)' ?>
 
-  <Product Name='Citrix Xen Windows $(var.arch) PV Drivers' Id='$(var.ProductId)'
+  <Product Name='Citrix Xen Windows $(var.arch) Preview PV Drivers For Windows 10 Only' Id='$(var.ProductId)'
       Language='1033' Codepage='1252' 
       Version='$(var.CurrentMajorVersion).$(var.CurrentMinorVersion).$(var.CurrentBuildVersion)' 
       Manufacturer='Citrix'
       UpgradeCode='$(var.UpgradeCode)' >
     <Package Id='*' Keywords='Citrix Xen Drivers' Description='Citrix Xen Windows Drivers'
-             Comments='Paravitualized Windows Drivers For Citrix XenServer' Manufacturer='Citrix'
+             Comments='Preview Paravitualized Windows Drivers For Citrix XenServer.  Windows 10 Only' Manufacturer='Citrix'
              InstallerVersion='200' Languages='1033' Compressed='yes'
 
              Platform='$(var.arch)'
@@ -186,8 +186,8 @@
     </Condition>
    
 
-    <Condition Message="These Citrix Xen PV Drivers for Windows require Windows Vista, Windows Server 2008 or Later">
-        <![CDATA[Installed OR (VersionNT>=600)]]>
+    <Condition Message="These Preview Citrix Xen PV Drivers for Windows require Windows 10">
+        <![CDATA[Installed OR (VersionNT>=603)]]>
     </Condition>
     <Media Id='1' Cabinet='XenDriversInstaller.cab' EmbedCab='yes' />
     <Directory Id='TARGETDIR' Name='SourceDir'>

--- a/src/installwizard/installwizard.wxs
+++ b/src/installwizard/installwizard.wxs
@@ -57,11 +57,11 @@
       <?define certs= 'f056d833-6b1f-4c9d-9636-f26ff3a75292' ?>
       <?define pf="ProgramFilesFolder" ?>
 
-  <Product Name='Citrix XenServer Tools Installer' Id='$(var.ProductId)'
+  <Product Name='Citrix Preview XenServer Tools Installer For Windows 10 Only' Id='$(var.ProductId)'
            Language='1033' Codepage='1252' Version='$(var.CurrentMajorVersion).$(var.CurrentMinorVersion).$(var.CurrentBuildVersion)' Manufacturer='Citrix'
            UpgradeCode='$(var.UpgradeCode)' >
     <Package Id='*' Keywords='Citrix XenServer Windows Installer' Description='PV Tools Install Wizard'
-             Comments='Installs Citrix XenServer Tools' Manufacturer='Citrix'
+             Comments='Installs Preview Citrix XenServer Tools For Windows 10 Only' Manufacturer='Citrix'
              InstallerVersion='200' Languages='1033' Compressed='yes'
              InstallScope='perMachine'
              SummaryCodepage='1252' />
@@ -220,7 +220,9 @@
     <Condition Message="A later version of [ProductName] is already installed.  Setup will now exit">
         <![CDATA[((NOT UPGRADINGNEWERVERSION) OR (FORCEINSTALL="1"))]]>
     </Condition>
-
+    <Condition Message="These Preview Citrix Xenserver PV Tools for Windows require Windows 10">
+        <![CDATA[Installed OR (VersionNT>=603)]]>
+    </Condition>
     <Property Id="NETFRAMEWORK4XFULL">
         <RegistrySearch Id="NetFramework4xFull" Root="HKLM" 
             Key="Software\Microsoft\NET Framework Setup\NDP\v4\Full"


### PR DESCRIPTION
Unfortunately, current Win10 previews report its VersionNt as 603 (win 8.1)
so we install on 8.1 and above, and have altered some text strings in the
installers to say "Windows 10 Preview" very clearly