### PR TITLE
CA-176746 : Do not unplug disk when upgrading xenvbd

### DIFF
--- a/src/installwizard/InstallWizard/Support.cs
+++ b/src/installwizard/InstallWizard/Support.cs
@@ -2102,7 +2102,15 @@ namespace InstallWizard
             finally {
                 Trace.WriteLine("root#xenevtchn key not present in CDDB");
             }
-            
+            try
+            {
+                Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Services\xenfilt\unplug",true).DeleteValue("DISKS");
+            }
+            catch (Exception e)
+            {
+                Trace.WriteLine("Disks still scheduled to be unplugged "+e.ToString());
+            }
+           
         }
 
         bool checkservicerunning(string name)


### PR DESCRIPTION
We want to switch to emulated for boot, so that if xenvbd/xenbus
compatability breaks, we can still boot up