### PR TITLE
CA-176746 : Don't unplug NICs on upgrade

### DIFF
--- a/src/installwizard/InstallWizard/Support.cs
+++ b/src/installwizard/InstallWizard/Support.cs
@@ -2112,6 +2112,14 @@ namespace InstallWizard
                 {
                     Trace.WriteLine("Disks still scheduled to be unplugged " + e.ToString());
                 }
+                try
+                {
+                    Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Services\xenfilt\unplug", true).DeleteValue("NICS");
+                }
+                catch (Exception e)
+                {
+                    Trace.WriteLine("NICs still scheduled to be unplugged " + e.ToString());
+                }
             }
         }
 


### PR DESCRIPTION
This is needed in case the NICs have been set to bootstart by PVS