### PR TITLE
ca-176746 : Once we've unplugged net drivers, xenvif doesn't need to

### DIFF
--- a/src/installwizard/InstallWizard/Support.cs
+++ b/src/installwizard/InstallWizard/Support.cs
@@ -2115,6 +2115,7 @@ namespace InstallWizard
                 try
                 {
                     Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Services\xenfilt\unplug", true).DeleteValue("NICS");
+                    Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Services\xenvif", true).SetValue("Start", 3, RegistryValueKind.DWord);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
be boot start