### PR TITLE
CP-13459 : introduce xenprep into installer build

### DIFF
--- a/build.py
+++ b/build.py
@@ -195,6 +195,7 @@ def make_builds(pack):
         shutil.copytree(pack+"\\xeniface", "installer\\builds\\xeniface")
         shutil.copytree(pack+"\\xenguestagent", "installer\\builds\\xenguestagent")
         shutil.copytree(pack+"\\xenvss", "installer\\builds\\xenvss")
+        shutil.copytree(pack+"\\xenprep", "installer\\builds\\xenprep")
 
 def make_installers(pack):
     src = ".\\src\\drivers"
@@ -502,6 +503,12 @@ if __name__ == '__main__':
     copyfiles('installwizard', 'qnetsettings', location,'x64', debug=False)
     copyfiles('installwizard', 'qnetsettings', location,'Win32', debug=False)
     make_installers(location)
+
+
+    msbuild('xenprep','Any CPU', False)
+    if signfiles:
+        sign(os.sep.join([getsrcpath('xenprep', debug=False),"xenprep.exe"]), signname, signstr=signstr)
+    copyfiles('xenprep', 'xenprep', location, debug=False)
 
     make_pe(location)
     make_builds(location)

--- a/proj/XenPrep.sln
+++ b/proj/XenPrep.sln
@@ -1,0 +1,20 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xenprep", "..\src\xenprep\Xenprep.csproj", "{17BDA712-F12F-4EF9-85E2-C20B25BD86AC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{17BDA712-F12F-4EF9-85E2-C20B25BD86AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{17BDA712-F12F-4EF9-85E2-C20B25BD86AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{17BDA712-F12F-4EF9-85E2-C20B25BD86AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{17BDA712-F12F-4EF9-85E2-C20B25BD86AC}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/xenprep/Progress.Designer.cs
+++ b/src/xenprep/Progress.Designer.cs
@@ -1,0 +1,71 @@
+﻿namespace Xenprep
+{
+    partial class Progress
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.progressBar = new System.Windows.Forms.ProgressBar();
+            this.Caption = new System.Windows.Forms.Label();
+            this.SuspendLayout();
+            // 
+            // progressBar
+            // 
+            this.progressBar.Location = new System.Drawing.Point(12, 72);
+            this.progressBar.Name = "progressBar";
+            this.progressBar.Size = new System.Drawing.Size(260, 23);
+            this.progressBar.TabIndex = 0;
+            // 
+            // Caption
+            // 
+            this.Caption.Location = new System.Drawing.Point(12, 9);
+            this.Caption.Name = "Caption";
+            this.Caption.Size = new System.Drawing.Size(260, 49);
+            this.Caption.TabIndex = 1;
+            // 
+            // Progress
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(284, 107);
+            this.Controls.Add(this.Caption);
+            this.Controls.Add(this.progressBar);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "Progress";
+            this.Text = "XenPrep Progress";
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        public System.Windows.Forms.ProgressBar progressBar;
+        public System.Windows.Forms.Label Caption;
+    }
+}
+

--- a/src/xenprep/Progress.cs
+++ b/src/xenprep/Progress.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+
+namespace Xenprep
+{
+    public partial class Progress : Form
+    {
+        public Progress()
+        {
+            InitializeComponent();
+            progressBar.Maximum = 100;
+            progressBar.Minimum = 0;
+        }
+    }
+}

--- a/src/xenprep/Progress.resx
+++ b/src/xenprep/Progress.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/xenprep/XenPrep.cs
+++ b/src/xenprep/XenPrep.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+using System.Threading;
+
+namespace Xenprep
+{
+    static class XenPrep
+    {
+        /// <summary>
+        /// The main entry point for the application.
+        /// </summary>
+        [STAThread]
+        static void Main(string[] args)
+        {
+            Progress progressWindow;
+            PrepareThread prepareThread;
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+
+            progressWindow = new Progress();
+            prepareThread = new PrepareThread(args, progressWindow);
+
+            Thread backgroundThread = new Thread(new ThreadStart(prepareThread.Run));
+            backgroundThread.Start();
+
+            Application.Run(progressWindow);
+            
+
+        }
+    }
+
+    class PrepareThread
+    {
+        Progress progressWindow;
+        public PrepareThread(string[] args, Progress progressWindow)
+        {
+            this.progressWindow = progressWindow;
+            this.cliargs = args;
+        }
+        string[] cliargs;
+
+        public void Run()
+        {
+            SetProgress(0);
+            
+            SetCaption("Lock CD Drive");
+            XenPrepSupport.LockCD();
+            Thread.Sleep(1000);
+            
+            SetProgress(10);
+            
+            SetCaption("Set restore point");
+            XenPrepSupport.SetRestorePoint();
+            Thread.Sleep(1000);
+
+            SetProgress(20);
+
+            SetCaption("Store network settings");
+            XenPrepSupport.StoreNetworkSettings();
+            Thread.Sleep(1000);
+
+            SetProgress(30);
+
+            SetCaption("Remove reliance on PV drivers");
+            XenPrepSupport.RemovePVDriversFromFilters();
+            XenPrepSupport.DontBootStartPVDrivers();
+            Thread.Sleep(1000);
+
+            SetProgress(40);
+
+            SetCaption("Set restore point");
+            XenPrepSupport.SetRestorePoint();
+            Thread.Sleep(1000);
+
+            SetProgress(50);
+
+            SetCaption("Remove Installer Packages");
+            XenPrepSupport.UninstallMSIs();
+            XenPrepSupport.UninstallXenLegacy();        
+            Thread.Sleep(1000);
+
+            SetProgress(60);
+
+            SetCaption("Clean up drivers");
+            XenPrepSupport.CleanUpPVDrivers();
+            Thread.Sleep(1000);
+
+            SetProgress(70);
+
+            SetCaption("Install new guest agent");
+            XenPrepSupport.InstallGuestAgent();
+            Thread.Sleep(1000);
+
+            SetProgress(80);
+
+            Thread.Sleep(1000);
+
+            SetProgress(90);
+
+            SetCaption("Unlock CD Drive");
+            XenPrepSupport.UnlockCD();
+            Thread.Sleep(1000);
+            
+            SetProgress(100);
+
+            CloseProgressWindow();
+
+        }
+
+        void SetCaption(string caption)
+        {
+            progressWindow.Invoke((MethodInvoker)(() =>
+            {
+                progressWindow.Caption.Text = caption;
+            }));
+        }
+
+        void SetProgress(int value)
+        {
+            progressWindow.Invoke((MethodInvoker)(() =>
+            {
+                progressWindow.progressBar.Value = value;
+            }));
+        }
+
+        void CloseProgressWindow()
+        {
+            progressWindow.Invoke((MethodInvoker)(() =>
+            {
+                progressWindow.Close();
+            }));
+        }
+    }
+
+}

--- a/src/xenprep/XenPrepSupport.cs
+++ b/src/xenprep/XenPrepSupport.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Xenprep
+{
+    class XenPrepSupport
+    {
+        public static void LockCD() {}
+        public static void SetRestorePoint() {}
+        public static void StoreNetworkSettings() {}
+        public static void RemovePVDriversFromFilters() {}
+        public static void DontBootStartPVDrivers() {}
+        public static void UninstallMSIs() {}
+        public static void UninstallXenLegacy() {}        
+        public static void CleanUpPVDrivers() {}
+        public static void InstallGuestAgent() {}
+        public static void UnlockCD() { }
+    }
+}

--- a/src/xenprep/Xenprep.csproj
+++ b/src/xenprep/Xenprep.csproj
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{17BDA712-F12F-4EF9-85E2-C20B25BD86AC}</ProjectGuid>
+    <OutputType>WinExe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Xenprep</RootNamespace>
+    <AssemblyName>Xenprep</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\proj\xenprep\bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\proj\xenprep\bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Deployment" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Progress.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Progress.designer.cs">
+      <DependentUpon>Progress.cs</DependentUpon>
+    </Compile>
+    <Compile Include="XenPrep.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="XenPrepSupport.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <EmbeddedResource Include="Progress.resx">
+      <DependentUpon>Progress.cs</DependentUpon>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
Currently a stub version of the xenprep utility which does nothing useful
It is included in installer/builds (and thus in the output collected
in the installer tar file, but not used beyond that point)

The intent is that all useful functionality will go into XenPrepSupport.cs,
which may also be included by other tasks that require the same functionality
(in particular the installwizard)