### PR TITLE
CA-178665 : Work around bug where xen.sys crashes if SystemStartOptio…

### DIFF
--- a/src/installwizard/InstallWizard/Support.cs
+++ b/src/installwizard/InstallWizard/Support.cs
@@ -2092,9 +2092,57 @@ namespace InstallWizard
             }
         }
 
+        public void workaroundSystemStartOptions()
+        {
+            RegistryKey control;
+            try {
+                control= Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Control", false);
+            }
+            catch {
+                Trace.WriteLine("Unable to open control key");
+                return;
+            }
+            try
+            {
+                string ssv = (string)control.GetValue("SystemStartOptions");
+                if (ssv != "")
+                {
+                    Trace.WriteLine("No need to workaround SystemStartOptions (value not empty)");
+                    return;
+                }
+            }
+            catch
+            {
+                Trace.WriteLine("No need to workaround SystemStartOptions (no such value)");
+                return;
+            }
+            try
+            {
+                Trace.WriteLine("Setting loadoptions");
+                ProcessStartInfo start = new ProcessStartInfo();
+                start.Arguments = "/set LOADOPTIONS XEN:NONE";
+                start.FileName = Environment.GetFolderPath(Environment.SpecialFolder.System) + "\\bcdedit.exe";
+                Trace.WriteLine("Using: " + start.FileName);
+                start.WindowStyle = ProcessWindowStyle.Hidden;
+                start.CreateNoWindow = true;
+
+                using (Process proc = Process.Start(start))
+                {
+                    proc.WaitForExit();
+                }
+            }
+            catch (Exception e)
+            {
+                Trace.WriteLine("Setting loadopitons failed : " + e.ToString());
+            }
+        }
+
         public void install(string args, string logfile, InstallerState installstate, bool driverupgrade)
         {
             //addcerts(installdir);
+
+            workaroundSystemStartOptions();
+
             Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Services\partmgr\Parameters", true).SetValue("SanPolicy", 0x00000001);
             base.install(args, logfile, installstate);
             enumerateBus();


### PR DESCRIPTION
…ns is an empty string

This is a workaround which gives us an immediate fix which can be backported to installers of drivers version 7.* without need for a driver re-whql