### PR TITLE
CP-13738 & CP-13460: Lock, Unlock and Eject Optical Discs

### DIFF
--- a/src/xenprep/XenPrep.cs
+++ b/src/xenprep/XenPrep.cs
@@ -55,7 +55,7 @@ namespace Xenprep
                 SetProgress(0);
 
                 SetCaption("Lock CD Drive");
-                XenPrepSupport.LockCD();
+                XenPrepSupport.LockCDs();
                 Thread.Sleep(1000);
 
                 SetProgress(10);
@@ -109,10 +109,11 @@ namespace Xenprep
                 SetProgress(90);
 
                 SetCaption("Unlock CD Drive");
-                XenPrepSupport.UnlockCD();
+                XenPrepSupport.UnlockCDs();
                 Thread.Sleep(1000);
 
                 SetProgress(100);
+                XenPrepSupport.EjectCDs();
                 CloseProgressWindow();
             }
             catch(Exception e)


### PR DESCRIPTION
Lock all optical drives at the start of XenPrep;
Unlock them in the end and eject them.

Signed-off-by: Kostas Ladopoulos <konstantinos.ladopoulos@citrix.com>