### PR TITLE
CA-180819: Make XenPrep run on .NET >= 4.0

### DIFF
--- a/src/xenprep/Xenprep.csproj
+++ b/src/xenprep/Xenprep.csproj
@@ -76,6 +76,12 @@
       <LogicalName>Xenprep._32.qnetsettings.exe</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="Xenprep.exe.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <SubType>Designer</SubType>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/xenprep/Xenprep.exe.config
+++ b/src/xenprep/Xenprep.exe.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v2.0.50727"/>
+    <supportedRuntime version="v4.0"/>
+  </startup>
+</configuration>


### PR DESCRIPTION
Added config file that enables XenPrep to run on .NET >= 4.0.

Signed-off-by: Kostas Ladopoulos <konstantinos.ladopoulos@citrix.com>