### PR TITLE
CA-183597 : incorporate DifXAPI.dll into installwizard

### DIFF
--- a/src/installwizard/installwizard.wxs
+++ b/src/installwizard/installwizard.wxs
@@ -321,6 +321,12 @@
                             Name='XenPVInstall' 
                             Wait='yes' />
                     </Component>
+                    <Component Id="DifXAPIDLL64" Guid="*">
+                        <File Id="difxapi64" Name="difxapi64.dll" Source="$(env.KIT)\Redist\DIFx\DIFxAPI\x64\difxapi.dll" />
+                    </Component>
+                    <Component Id="DifXAPIDLL32" Guid="*">
+                        <File Id="difxapi32" Name="difxapi32.dll" Source="$(env.KIT)\Redist\DIFx\DIFxAPI\x86\difxapi.dll" />
+                    </Component>
                 </Directory>
             </Directory>
          </Directory>
@@ -391,6 +397,8 @@
         <ComponentRef Id='UIEvent'/>
         <ComponentRef Id='RegEntry'/>
         <ComponentRef Id='InstallService'/>
+        <ComponentRef Id="DifXAPIDLL32" />
+        <ComponentRef Id="DifXAPIDLL64" />
         <ComponentRef Id='Msis' />
         <ComponentRef Id='LegacyInstaller' />
         <ComponentRef Id='InstallStatus' />


### PR DESCRIPTION
The way this works is:

We have to include both the 64 bit and the 32 bit difxapi.dll for .net's sake
So we give them different names
Then use object abstraction so only one of the 32 or 64 bit interfaces are visible to the code.