### PR TITLE
Revert "CA-184369 : Don't block install if we've removed driver details"

### DIFF
--- a/src/installwizard/InstallWizard/Support.cs
+++ b/src/installwizard/InstallWizard/Support.cs
@@ -2084,7 +2084,6 @@ namespace InstallWizard
                     && (pciDeviceName != "Citrix PV Bus") // Citrix XenServer Standard Drivers
                     && (pciDeviceName != "Citrix PV SCSI Host Adapter") // Legacy Drivers
                     && (pciDeviceName != "Citrix XenServer PV SCSI Host Adapter") // 5.5 Legacy Drivers
-                    && (pciDeviceName != "") //No device name found (we've probably deleted it)
                    ) 
                 {
                     return true;


### PR DESCRIPTION
Reverts xenserver/win-installer#221

This change was incorrect - we want to install if we have an empty driver name, not block the install.