### PR TITLE
Remove component 'dotnetfouragent'

### DIFF
--- a/src/agent/managementagent.wxs
+++ b/src/agent/managementagent.wxs
@@ -397,7 +397,6 @@
         <?if $(var.usecerts)=yes ?>
             <ComponentRef Id='Certs' />
         <?endif?>
-        <ComponentRef Id='dotnetfouragent'/>
         <ComponentRef Id='dotnetagentsupport'/>
         <MergeRef Id='Drivers' />
         <ComponentRef Id='NetSettingsCpy' />


### PR DESCRIPTION
Remove stale component. Management Agent msi does not build

Signed-off-by: Kostas Ladopoulos <konstantinos.ladopoulos@citrix.com>