### PR TITLE
CA-197641: If legacy tools present, write registry entry

### DIFF
--- a/src/PVDriversRemoval/PVDriversPurge.cs
+++ b/src/PVDriversRemoval/PVDriversPurge.cs
@@ -123,12 +123,14 @@ namespace PVDriversRemoval
                 @"SYSTEM\CurrentControlSet\Services";
             const string START = "Start";
             const string XENFILT_UNPLUG = @"xenfilt\Unplug";
+            const string XENEVTCHN = "xenevtchn";
+            const string NOPVBOOT = "NoPVBoot";
             const int MANUAL = 3;
 
             string[] xenServices = {
                 "XENBUS", "xenfilt", "xeniface", "xenlite",
                 "xennet", "xenvbd", "xenvif", "xennet6",
-                "xenutil", "xenevtchn"
+                "xenutil", XENEVTCHN
             };
 
             Trace.WriteLine("===> " + FUNC_NAME);
@@ -166,6 +168,17 @@ namespace PVDriversRemoval
                     );
                     tmpRK.DeleteValue("DISKS", false);
                     tmpRK.DeleteValue("NICS", false);
+                }
+            }
+
+            using (RegistryKey tmpRK = baseRK.OpenSubKey(XENEVTCHN, true))
+            {
+                if (tmpRK != null)
+                // If this is not set, the VM BSODs at
+                // boot time (only on legacy drivers)
+                {
+                    tmpRK.SetValue(NOPVBOOT, 1, RegistryValueKind.DWord);
+                    Trace.WriteLine(XENEVTCHN + @"\" + NOPVBOOT + " = 1");
                 }
             }
 


### PR DESCRIPTION
If legacy tools are being used, an extra registry entry is
needed to make the drivers not bootstart after reboot

Signed-off-by: Kostas Ladopoulos <konstantinos.ladopoulos@citrix.com>