### PR TITLE
CP-14538:  Ensure drivers set to bootstart start at boot time

### DIFF
--- a/src/InstallAgent/InstallAgent.cs
+++ b/src/InstallAgent/InstallAgent.cs
@@ -168,13 +168,17 @@ namespace InstallAgent
 
                 Helpers.ChangeServiceStartMode(
                     this.ServiceName,
-                    ServiceStartMode.Manual
+                    Helpers.ExpandedServiceStartMode.Manual
                 );
+
+                Helpers.EnsureBootStartServicesStartAtBoot();
 
                 SetInstallStatus("Installed");
             }
             else
             {
+                Helpers.EnsureBootStartServicesStartAtBoot();
+
                 if (rebootOption == RebootType.AUTOREBOOT)
                 {
                     TryReboot();


### PR DESCRIPTION
It appears windows can 'forget' a driver is bootstart - so this ensures windows is told our bootstart drivers are also boot start.

We check drivers which are not bootstart in case a user (such as PVS) has set them to start at boot time