### PR TITLE
CP-14538:  Ensure drivers set to bootstart start at boot time

### DIFF
--- a/src/HelperFunctions/Helpers.cs
+++ b/src/HelperFunctions/Helpers.cs
@@ -7,11 +7,16 @@ using System.Security.Cryptography.X509Certificates;
 using System.ServiceProcess;
 using System.Text;
 using System.Threading;
+using Microsoft.Win32;
 
 namespace HelperFunctions
 {
     public static class Helpers
     {
+        public const string HKLM = @"HKEY_LOCAL_MACHINE\";
+        public const string REGISTRY_SERVICES_KEY =
+            @"SYSTEM\CurrentControlSet\Services\";
+
         public static void Reboot()
         {
             Trace.WriteLine("OK - shutting down");
@@ -112,9 +117,19 @@ namespace HelperFunctions
             return (int)Math.Log((double)flag, 2.0);
         }
 
+        public enum ExpandedServiceStartMode : uint {
+            // Contains service start modes for drivers and user services
+            Boot        = 0,
+            System      = 1,
+            Automatic   = 2,
+            Manual      = 3, //User Services
+            Demand      = 3, //Drivers
+            Disabled    = 4,
+        }
+
         public static bool ChangeServiceStartMode(
             string serviceName,
-            ServiceStartMode mode)
+            ExpandedServiceStartMode mode)
         {
             Trace.WriteLine(
                 "Changing Start Mode of service: \'" + serviceName + "\'"
@@ -172,6 +187,39 @@ namespace HelperFunctions
             );
 
             return true;
+        }
+
+
+        public static void EnsureBootStartServicesStartAtBoot()
+        // This is a function which at first glance appears pointless
+        // It runs through all of our services registry entries, and
+        // if it finds they are boot start, it changes their start mode
+        // to be boot start.
+        // The Reason:  If we move xenbus to be non-boot start,
+        // then reinstall the same version of xenbus, it will become boot
+        // start.  But other boot start drivers hanging off it seem to become
+        // forgotten by Windows.  This function reminds Windows about them.
+        {
+            string[] services = {
+                "xenbus", "xendisk", "xenvbd", "xenvif", "xennet", "xeniface",
+            };
+
+            foreach (string service in services) {
+                if ((Int32)Registry.GetValue(
+                        HKLM + REGISTRY_SERVICES_KEY + service, 
+                        "start", 
+                        4
+                    ) == (Int32)ExpandedServiceStartMode.Boot)
+                {
+                    Trace.WriteLine("ensure service " + service 
+                        + " is boot start");
+                    
+                    ChangeServiceStartMode(
+                        service, 
+                        ExpandedServiceStartMode.Boot
+                    );
+                }
+            }
         }
 
         public static bool DeleteService(string serviceName)

--- a/src/InstallAgent/InstallAgent.cs
+++ b/src/InstallAgent/InstallAgent.cs
@@ -168,13 +168,17 @@ namespace InstallAgent
 
                 Helpers.ChangeServiceStartMode(
                     this.ServiceName,
-                    ServiceStartMode.Manual
+                    Helpers.ExpandedServiceStartMode.Manual
                 );
+
+                Helpers.EnsureBootStartServicesStartAtBoot();
 
                 SetInstallStatus("Installed");
             }
             else
             {
+                Helpers.EnsureBootStartServicesStartAtBoot();
+
                 if (rebootOption == RebootType.AUTOREBOOT)
                 {
                     TryReboot();

--- a/src/InstallAgent/PVDevice/PVDevice.cs
+++ b/src/InstallAgent/PVDevice/PVDevice.cs
@@ -86,7 +86,7 @@ namespace PVDevice
             Trace.WriteLine(emulatedDevice + ": checking if reboot needed");
 
             using (RegistryKey key = Registry.LocalMachine.OpenSubKey(
-                @"SYSTEM\CurrentControlSet\services\" +
+                Helpers.REGISTRY_SERVICES_KEY +
                 emulatedDevice + @"\Status"))
             {
                 if (key != null &&

--- a/src/InstallAgent/PVDevice/XenVif.cs
+++ b/src/InstallAgent/PVDevice/XenVif.cs
@@ -1,6 +1,7 @@
 ﻿using HardwareDevice;
 using Microsoft.Win32;
 using PInvokeWrap;
+using HelperFunctions;
 using State;
 using System;
 using System.Diagnostics;
@@ -101,7 +102,7 @@ namespace PVDevice
             // and we don't have any aliases listed,
             // generate aliases as per the coinstaller
             RegistryKey netKey = Registry.LocalMachine.OpenSubKey(
-                @"SYSTEM\CurrentControlSet\services\xennet\enum"
+                Helpers.REGISTRY_SERVICES_KEY+@"xennet\enum"
             );
 
             if (netKey == null)
@@ -140,7 +141,7 @@ namespace PVDevice
         private static void BuildAlias(int index, string devicePath)
         {
             RegistryKey vifKey = Registry.LocalMachine.OpenSubKey(
-                @"SYSTEM\CurrentControlSet\services\xenvif",
+                Helpers.REGISTRY_SERVICES_KEY+@"xenvif",
                 true
             );
 

--- a/src/PVDriversRemoval/PVDriversPurge.cs
+++ b/src/PVDriversRemoval/PVDriversPurge.cs
@@ -124,8 +124,7 @@ namespace PVDriversRemoval
         public static void DontBootStartPVDrivers()
         {
             const string FUNC_NAME = "DontBootStartPVDrivers";
-            const string BASE_RK_NAME =
-                @"SYSTEM\CurrentControlSet\Services";
+            const string BASE_RK_NAME = Helpers.REGISTRY_SERVICES_KEY;
             const string START = "Start";
             const string XENFILT_UNPLUG = @"xenfilt\Unplug";
             const string XENEVTCHN = "xenevtchn";


### PR DESCRIPTION
It appears windows can 'forget' a driver is bootstart - so this ensures windows is told our bootstart drivers are also boot start.

We check drivers which are not bootstart in case a user (such as PVS) has set them to start at boot time