### PR TITLE
Change "wait for drivers to install" timeout

### DIFF
--- a/src/InstallAgent/InstallAgent.cs
+++ b/src/InstallAgent/InstallAgent.cs
@@ -209,14 +209,12 @@ namespace InstallAgent
 
             if (VM.GetOtherDriverInstallingOnFirstRun())
             {
-                timeout = 20; // arbitrarily chosen;
-
                 Trace.WriteLine(
                     "Something was installing before " +
                     "Install Agent's first run."
                 );
 
-                timeout = 20 * 60; // 20 minutes to seconds
+                timeout = 600; // seconds; arbitrarily chosen
             }
             else
             {


### PR DESCRIPTION
Reduce the waiting time from 20 minutes to 10 before an
auto-reboot, if there was a driver installing before
InstallAgent's first run

Signed-off-by: Kostas Ladopoulos <konstantinos.ladopoulos@citrix.com>