### PR TITLE
CP-16417: Inform Setup.exe initiator about InstallAgent outcome

### DIFF
--- a/build.py
+++ b/build.py
@@ -240,9 +240,9 @@ def make_setup_header():
     for culture in culturelist:
         file.write("const TCHAR * list_"+culture.languagecode['culture']+"[] = {\n")
         for key in keylist:
-            file.write("_T(\""+culture.branding[key]+"\"),\n")
+            file.write("_T(\"" + culture.branding[key].replace("\\", "\\\\") + "\"),\n")
         for key in filekeylist:
-            file.write("_T(\""+culture.filenames[key]+"\"),\n")
+            file.write("_T(\"" + culture.filenames[key].replace("\\", "\\\\") + "\"),\n")
         file.write("};\n")
 
     for culture in culturelist:

--- a/src/PInvokeWrap/AdvApi32.cs
+++ b/src/PInvokeWrap/AdvApi32.cs
@@ -28,6 +28,63 @@ namespace PInvokeWrap
             public LUID_AND_ATTRIBUTES[] Privileges;
         }
 
+        public enum TOKEN_INFORMATION_CLASS
+        {
+            TokenUser                             = 1,
+            TokenGroups,
+            TokenPrivileges,
+            TokenOwner,
+            TokenPrimaryGroup,
+            TokenDefaultDacl,
+            TokenSource,
+            TokenType,
+            TokenImpersonationLevel,
+            TokenStatistics,
+            TokenRestrictedSids,
+            TokenSessionId,
+            TokenGroupsAndPrivileges,
+            TokenSessionReference,
+            TokenSandBoxInert,
+            TokenAuditPolicy,
+            TokenOrigin,
+            TokenElevationType,
+            TokenLinkedToken,
+            TokenElevation,
+            TokenHasRestrictions,
+            TokenAccessInformation,
+            TokenVirtualizationAllowed,
+            TokenVirtualizationEnabled,
+            TokenIntegrityLevel,
+            TokenUIAccess,
+            TokenMandatoryPolicy,
+            TokenLogonSid,
+            TokenIsAppContainer,
+            TokenCapabilities,
+            TokenAppContainerSid,
+            TokenAppContainerNumber,
+            TokenUserClaimAttributes,
+            TokenDeviceClaimAttributes,
+            TokenRestrictedUserClaimAttributes,
+            TokenRestrictedDeviceClaimAttributes,
+            TokenDeviceGroups,
+            TokenRestrictedDeviceGroups,
+            TokenSecurityAttributes,
+            TokenIsRestricted,
+            MaxTokenInfoClass
+        }
+
+        public struct TOKEN_USER
+        {
+            public SID_AND_ATTRIBUTES User;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SID_AND_ATTRIBUTES
+        {
+            public IntPtr Sid;
+            public int Attributes;
+        }
+
         // The place/naming of the following constants
         // may not be the best, but will do for now.
         public const string SE_SHUTDOWN_NAME = "SeShutdownPrivilege";
@@ -235,5 +292,21 @@ namespace PInvokeWrap
         [DllImport("advapi32.dll", SetLastError = true)]
         public static extern bool DeleteService(IntPtr hService);
         // ------------- End -------------
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        public static extern bool GetTokenInformation(
+                IntPtr                  TokenHandle,
+                TOKEN_INFORMATION_CLASS TokenInformationClass,
+                IntPtr                  TokenInformation,
+                UInt32                  TokenInformationLength,
+            out UInt32                  ReturnLength
+        );
+
+        // Using IntPtr for pSID insted of Byte[]
+        [DllImport("advapi32", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern bool ConvertSidToStringSid(
+                IntPtr pSID,
+            out IntPtr ptrSid
+        );
     }
 }

--- a/src/PInvokeWrap/Kernel32.cs
+++ b/src/PInvokeWrap/Kernel32.cs
@@ -16,5 +16,11 @@ namespace PInvokeWrap
 
         [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
         public static extern IntPtr GetModuleHandle(string moduleName);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool CloseHandle(IntPtr hObject);
+
+        [DllImport("kernel32.dll")]
+        public static extern IntPtr LocalFree(IntPtr hMem);
     }
 }

--- a/src/PInvokeWrap/WinError.cs
+++ b/src/PInvokeWrap/WinError.cs
@@ -6,6 +6,7 @@
     // for.
     {
         public const int ERROR_SUCCESS                  = 0;
+        public const int ERROR_INSUFFICIENT_BUFFER      = 122;
         public const int ERROR_NO_MORE_ITEMS            = 259;
         public const int ERROR_SUCCESS_REBOOT_INITIATED = 1641;
         public const int ERROR_SUCCESS_REBOOT_REQUIRED  = 3010;

--- a/src/PInvokeWrap/WtsApi32.cs
+++ b/src/PInvokeWrap/WtsApi32.cs
@@ -85,13 +85,13 @@ namespace PInvokeWrap
         }
 
         public static readonly IntPtr WTS_CURRENT_SERVER_HANDLE = IntPtr.Zero;
-        // public const int WTS_CURRENT_SESSION = 1;
+        public static readonly uint   WTS_CURRENT_SESSION       = 0xFFFFFFFF;
+        //                                                        ((DWORD) - 1)
 
         [DllImport(
             "wtsapi32.dll",
-            //CharSet = CharSet.Auto,
-            SetLastError = true,
-            EntryPoint = "WTSSendMessageA")]
+            CharSet = CharSet.Auto,
+            SetLastError = true)]
         public static extern bool WTSSendMessage(
                 IntPtr hServer,
                 uint   SessionId,
@@ -107,9 +107,8 @@ namespace PInvokeWrap
 
         [DllImport(
             "wtsapi32.dll",
-            //CharSet = CharSet.Auto,
-            SetLastError = true,
-            EntryPoint = "WTSEnumerateSessionsW")]
+            CharSet = CharSet.Auto,
+            SetLastError = true)]
         public static extern bool WTSEnumerateSessions(
                 IntPtr hServer,
                 uint   Reserved, // always 0
@@ -120,5 +119,11 @@ namespace PInvokeWrap
 
         [DllImport("wtsapi32.dll")]
         public static extern void WTSFreeMemory(IntPtr pMemory);
+
+        [DllImport("wtsapi32.dll", SetLastError = true)]
+        public static extern bool WTSQueryUserToken(
+                ulong  SessionId,
+            out IntPtr phToken
+        );
     }
 }


### PR DESCRIPTION
Present a MessageBox to the user who initiated the PV Tools installer
with a success/failure message the next time they log on after the
installer has finished.

This works as follows:
- Setup.exe gets the currently logged on user's SID and
  writes it under the 'InstallAgent' registry key
- When the InstallAgent has finished all work it:
  - Enumerates all sessions
  - If a session is active, compares the logged on user's
    SID with the initiator's SID
  - If they match, a message is sent to that user to inform
    them of the status of the install and the InstallAgent
    is put into 'Manual' startup mode
  - If not, a check is performed every 15 seconds until the
    initiator logs in and gets the message

Other changes:
- Escape backslashes in setup branding.h
- Setup.exe prompts the user for a reboot only in the driver
  upgrade case (e.g. from 7.x to 8.x) - in all other cases
  Windows takes care of it
- The 'SOFTWARE\..\InstallAgent' registry key is the *ONLY*
  place to get InstallAgent related info; all other places
  (e.g. XenToolsInstaller key) are populated for backwards
  compatibility and/or 3rd party dependencies)

Signed-off-by: Kostas Ladopoulos <konstantinos.ladopoulos@citrix.com>