### PR TITLE
CP-16527: [ManagementAgent] Write 'InstallMode' to Registry

### DIFF
--- a/src/agent/managementagent.wxs
+++ b/src/agent/managementagent.wxs
@@ -196,6 +196,11 @@
     <CustomAction Id="RebootOptionForce" Property="REBOOTOPTION" Value="AUTOREBOOT" />
     <CustomAction Id="RebootOptionForceDisableForce" Property="REBOOT" Value="ReallySuppress" />
     <CustomAction Id="RebootOptionNone" Property="REBOOTOPTION"  Value="NOREBOOT" />
+
+    <CustomAction Id="SetINSTALLMODE" Property="INSTALLMODE" Value="FULL" />
+    <CustomAction Id="InstallModeQuiet" Property="INSTALLMODE" Value="QUIET" />
+    <CustomAction Id="InstallModePassive" Property="INSTALLMODE" Value="PASSIVE" />
+
     <CustomAction Id="UninstallExe"
                   FileKey="UninstallerExe"
                   Execute="deferred"
@@ -226,6 +231,13 @@
         </Custom>
         <Custom Action="RebootOptionForceDisableForce" After="RebootOptionNone">
             REBOOT="Force"
+        </Custom>
+        <Custom Action="SetINSTALLMODE" Before="WriteRegistryValues" />
+        <Custom Action="InstallModeQuiet" After="SetINSTALLMODE">
+            UILevel=2
+        </Custom>
+        <Custom Action="InstallModePassive" After="SetINSTALLMODE">
+            UILevel=3 OR UILevel=4
         </Custom>
         <Custom Action="UninstallExe" Before="RemoveFiles">
             (NOT UPGRADINGPRODUCTCODE) AND (REMOVE="ALL")
@@ -404,6 +416,10 @@
           <RegistryKey Root="HKLM"
               Key='$(var.BRANDING_installAgentRegKey)'>
               <RegistryValue Type='string' Name='RebootOption' Value='[REBOOTOPTION]' />
+          </RegistryKey>
+          <RegistryKey Root="HKLM"
+              Key='$(var.BRANDING_installAgentRegKey)'>
+              <RegistryValue Type='string' Name='InstallMode' Value='[INSTALLMODE]' />
           </RegistryKey>
           <RemoveRegistryKey Root="HKLM"
               Key='$(var.BRANDING_installAgentRegKey)'


### PR DESCRIPTION
When installing Management Agent, write the 'InstallMode'
value to the InstallAgent registry key:
- Normal install => 'InstallMode' = FULL
- /quiet => 'InstallMode' = QUIET
- /passive => 'InstallMode' = PASSIVE

Signed-off-by: Kostas Ladopoulos <konstantinos.ladopoulos@citrix.com>