### PR TITLE
CA-206396: InstallAgent raises exception on opening reg key

### DIFF
--- a/src/InstallAgent/InstallAgent.cs
+++ b/src/InstallAgent/InstallAgent.cs
@@ -259,6 +259,9 @@ namespace InstallAgent
                     GetTimeoutToReboot()
                 );
 
+                // 'timeout' arbitrarily set to 30 minutes
+                Helpers.BlockUntilMsiMutexAvailable(new TimeSpan(0, 30, 0));
+
                 VM.IncrementRebootCount();
                 Helpers.Reboot();
 

--- a/src/InstallAgent/State/Installer.cs
+++ b/src/InstallAgent/State/Installer.cs
@@ -99,20 +99,19 @@ namespace State
         // state of the installer and initializes itself.
         static Installer()
         {
-            // In .NET 3.5: Creates a new subkey or opens an
-            //              existing subkey for write access
-            RegistryKey installStateRK =
-                Registry.LocalMachine.CreateSubKey(stateRegKey);
-
             currentState = 0;
 
-            for (int i = 0; i < statesDefault.Length; ++i)
+            using (RegistryKey installStateRK =
+                    Registry.LocalMachine.CreateSubKey(stateRegKey))
             {
-                int flag = (int) installStateRK.GetValue(
-                    statesDefault[i].Name, statesDefault[i].DefaultValue
-                );
+                for (int i = 0; i < statesDefault.Length; ++i)
+                {
+                    int flag = (int)installStateRK.GetValue(
+                        statesDefault[i].Name, statesDefault[i].DefaultValue
+                    );
 
-                currentState |= flag << i;
+                    currentState |= flag << i;
+                }
             }
         }
 


### PR DESCRIPTION
This behaviour is only seen on the driver upgrade case. After the first
reboot, InstallAgent is able to read the state of the installer from
the registry and continues where it left off (uninstalling the MSIs).
However, uninstalling 'Citrix XenTools Installer' takes ~10 minutes
to complete. After 'UninstallMSIs()' returns, we try to set the
'MSIsUninstalled' flag to the registry and an exception is raised
because it cannot be opened.

This commit comprises 2 possible fixes:
- Wait until the '_MSIExecute' mutex is available/free before
  rebooting (if AUTOREBOOT)
- Enclose the install state reg key in a 'using' statement in the
  'Installer' static constructor

Signed-off-by: Kostas Ladopoulos <konstantinos.ladopoulos@citrix.com>