### PR TITLE
CA-212319: Do not fail if newer drivers already installed

### DIFF
--- a/src/HelperFunctions/Helpers.cs
+++ b/src/HelperFunctions/Helpers.cs
@@ -442,17 +442,33 @@ namespace HelperFunctions
                 "Installing driver: \'" + Path.GetFileName(infPath) + "\'"
             );
 
-            if (!NewDev.DiInstallDriver(
-                    IntPtr.Zero,
-                    infPath,
-                    flags,
-                    out reboot))
+            NewDev.DiInstallDriver(
+                IntPtr.Zero,
+                infPath,
+                flags,
+                out reboot
+            );
+
+            Win32Error.Set("DiInstallDriver");
+
+            if (Win32Error.GetErrorNo() == WinError.ERROR_SUCCESS)
             {
-                Win32Error.Set("DiInstallDriver");
+                Trace.WriteLine("Driver installed successfully");
+            }
+            else if (Win32Error.GetErrorNo() == WinError.ERROR_NO_MORE_ITEMS)
+            // DiInstallDriver() returns ERROR_NO_MORE_ITEMS when the
+            // hardware ID in the inf file is found, but the specified
+            // driver is not a better match than the current one and
+            // DIIRFLAG_FORCE_INF is not used
+            {
+                Trace.WriteLine(
+                    "Driver not installed; newer driver already present"
+                );
+            }
+            else
+            {
                 throw new Exception(Win32Error.GetFullErrMsg());
             }
-
-            Trace.WriteLine("Driver installed successfully");
         }
 
         public static string[] StringArrayFromMultiSz(byte[] szz)


### PR DESCRIPTION
If newer drivers are installed for a hardware device,
DiInstallDriver() returns FALSE and sets Last Error
to ERROR_NO_MORE_ITEMS.

InstallDriver() is changed to not throw an exception when
DiInstallDriver() returns FALSE, but to check the Last
Error; if different than 0 or 259, throw.

Signed-off-by: Kostas Ladopoulos <konstantinos.ladopoulos@citrix.com>