### PR TITLE
CA-213907 : ensure lite agent WMI connection is reestablished

### DIFF
--- a/src/HelperFunctions/Helpers.cs
+++ b/src/HelperFunctions/Helpers.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
+using System.ServiceProcess;
 
 namespace HelperFunctions
 {
@@ -233,6 +234,36 @@ namespace HelperFunctions
                     );
                 }
             }
+        }
+
+        public static bool ServiceRestart(string name)
+        {
+            ServiceController sc;
+            try
+            {
+                sc = new ServiceController(name);
+            }
+            catch (ArgumentException e)
+            {
+                Trace.WriteLine(e.Message);
+                return false;
+            }
+
+            try
+            {
+                if ((sc.Status == ServiceControllerStatus.Running) && sc.CanStop)
+                {
+                    sc.Stop();
+                }
+                sc.WaitForStatus(ServiceControllerStatus.Stopped);
+                sc.Start();
+            }
+            catch (Exception e)
+            {
+                Trace.WriteLine(e.Message);
+                return false;
+            }
+            return true;
         }
 
         public static bool DeleteService(string serviceName)

--- a/src/InstallAgent/PVDevice/XenIface.cs
+++ b/src/InstallAgent/PVDevice/XenIface.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Management;
+using HelperFunctions;
 
 namespace PVDevice
 {
@@ -8,6 +9,7 @@ namespace PVDevice
     {
         // Only 1 session can be active at any time
         private static ManagementObject _session;
+        private static Boolean functioning = false;
 
         static XenIface()
         {
@@ -64,7 +66,15 @@ namespace PVDevice
                     return false;
                 }
             }*/
-
+            if (!functioning)
+            {
+                // This is a workaround to cope with xeniface being re-installed
+                // as xenlite is bad at reconnecting via WMI without a kick.
+                // This can be removed when the lite agent uses IOCTLS
+                Trace.WriteLine("Restart xenlite service");
+                Helpers.ServiceRestart("xenlite");
+                functioning = true;
+            }
             Trace.WriteLine("IFACE: device installed");
             return true;
         }


### PR DESCRIPTION
Following a reinstall of the same version of xeniface, the lite agent
fails to notice its WMI agent is broken.  As a workaround, having
installed Xeniface we restart the xenlite service.

When we move to a later lite agent which uses IOCTLs rather than
WMI, we can remove this workaround