### PR TITLE
CA-225008 : Do not reboot until we've checked if xeniface is

### DIFF
--- a/src/InstallAgent/InstallAgent.cs
+++ b/src/InstallAgent/InstallAgent.cs
@@ -136,6 +136,7 @@ namespace InstallAgent
 
         private void __InstallThreadHandler()
         {
+            bool needReboot = false;
             if (WinVersion.IsWOW64())
             {
                 throw new Exception("WOW64: Do not do that.");
@@ -190,19 +191,16 @@ namespace InstallAgent
 
             if (!Installer.EverythingInstalled())
             {
-                bool needReboot;
                 InstallCertificates();
                 PVDriversInstall(out needReboot);
-
-                if (needReboot)
-                {
-                    goto ExitReboot;
-                }
             }
 
             if (PVDevice.PVDevice.AllFunctioning())
             {
-                goto ExitDone;
+                if (needReboot)
+                    goto ExitReboot;
+                else
+                    goto ExitDone;
             }
             else
             {


### PR DESCRIPTION
functioning

As part of checking if xeniface is functioning (in the pre-xenagent
era only) the lite agent is restarted to ensure it reconnects via
wmi.  This was lost in the refactoring needed in the revised
mgmt agent merge