### PR TITLE
CA-258622: Fix unhandled exception in Helpers.ServiceRestart()

### DIFF
--- a/src/HelperFunctions/Helpers.cs
+++ b/src/HelperFunctions/Helpers.cs
@@ -252,10 +252,19 @@ namespace HelperFunctions
                 return false;
             }
 
-            if (!sc.CanStop)
+            try
             {
-                Trace.WriteLine("Service '" + name + "' cannot be stopped.");
+                if (!sc.CanStop)
+                {
+                    Trace.WriteLine("Service '" + name + "' cannot be stopped.");
+                    return false;
+                }
+            }
+            catch (InvalidOperationException e)
+            {
+                Trace.WriteLine(e.Message);
                 return false;
+
             }
 
             try
@@ -270,6 +279,7 @@ namespace HelperFunctions
                     sc.Stop();
                 }
 
+                sc.Refresh();
                 while (sc.Status != ServiceControllerStatus.Stopped)
                 {
                     Trace.WriteLine(
@@ -285,7 +295,7 @@ namespace HelperFunctions
                 Trace.WriteLine("Starting service: '" + name + "'.");
                 sc.Start();
             }
-            catch (Exception e)
+            catch (Win32Exception e)
             {
                 Trace.WriteLine(e.Message);
                 return false;


### PR DESCRIPTION
A 'ServiceController' object can be created with a non-existent
service. If this is the case, a call to the 'CanStop()' member
method of the object will throw an 'InvalidOperationException'.

Put the 'CanStop()' check in a try/catch block.

Also, add a call to 'Refresh()' before we check the 'Status'
field and replace the generic 'Exception' with 'Win32Exception',
since this is the only exception other than 'InvalidOperationException'
that 'Start()'/'Stop()' can throw.

Signed-off-by: Kostas Ladopoulos <konstantinos.ladopoulos@citrix.com>