### PR TITLE
Xenvif 152

### DIFF
--- a/manifestspecific.py
+++ b/manifestspecific.py
@@ -33,7 +33,7 @@ artifactory='https://repo.citrite.net:443/xs-local-build/'
 build_tar_source_files = {
        "xenguestagent" : r'win-xenguestagent/master/win-xenguestagent-219/xenguestagent.tar',
        "xenbus" : r'win-xenbus/patchq-8.2/win-xenbus-113/xenbus.tar',
-       "xenvif" : r'win-xenvif/patchq/win-xenvif-103/xenvif.signed.tar',
+       "xenvif" : r'win-xenvif/patchq/win-xenvif-152/xenvif.signed.tar',
        "xennet" : r'win-xennet/patchq/win-xennet-64/xennet.signed.tar',
        "xeniface" : r'win-xeniface/8.2/win-xeniface-102/xeniface.tar',
        "xenvbd" : r'win-xenvbd/patchq/win-xenvbd-158/xenvbd.tar',


### PR DESCRIPTION
Importing from upstream e4a153d3741b7cfd5c3389eafa94df2a33eed80c

Fix SDV
Update version to 8.2.1
Request reboot keys should be volatile
Clean up use of MmGetSystemAddressForMdlSafe()
Don't try to __FreePages() with local copy of MDL
Remove the explicit ExFreePool(Mdl) in TransmitterBuffe...
Fix memory leak in __FreePage()