### PR TITLE
Update to XenBus 115, XenCons 7

### DIFF
--- a/manifestspecific.py
+++ b/manifestspecific.py
@@ -32,8 +32,8 @@ artifactory='https://repo.citrite.net:443/xs-local-build/'
 
 build_tar_source_files = {
        "xenguestagent" : r'win-xenguestagent/master/win-xenguestagent-219/xenguestagent.tar',
-       "xenbus" : r'win-xenbus/patchq-9.x-vs2012/win-xenbus-114/xenbus.tar',
-       "xencons" : r'win-xencons/master/win-xencons-6/xencons.tar',
+       "xenbus" : r'win-xenbus/patchq-9.x-vs2012/win-xenbus-115/xenbus.tar',
+       "xencons" : r'win-xencons/master/win-xencons-7/xencons.tar',
        "xenvif" : r'win-xenvif/patchq/win-xenvif-152/xenvif.tar',
        "xennet" : r'win-xennet/patchq/win-xennet-64/xennet.signed.tar',
        "xeniface" : r'win-xeniface/8.2/win-xeniface-102/xeniface.tar',


### PR DESCRIPTION
* Disables xenbus default console logging
* Disables xencons default tty execution

Signed-off-by: Owen Smith <owen.smith@citrix.com>