### PR TITLE
CP-23143 Merge HFX Hokulea Fixes

### DIFF
--- a/manifestspecific-inspur.py
+++ b/manifestspecific-inspur.py
@@ -32,20 +32,15 @@ artifactory='https://repo.citrite.net:443/xs-local-build/'
 
 build_tar_source_files = {
         "xenguestagent" : r'win-xenguestagent/master/win-xenguestagent-219/xenguestagent.tar',
-        "xenbus": r"win-xenbus/patchq/win-xenbus-85/xenbus.inspur.signed.tar",
-        "xenvif": r"win-xenvif/patchq/win-xenvif-103/xenvif.inspur.signed.tar",
+        "xenbus": r"win-xenbus/patchq-8.2/win-xenbus-113/xenbus.inspur.signed.tar",
+        "xenvif": r"win-xenvif/patchq/win-xenvif-152/xenvif.signed.tar",
         "xennet": r"win-xennet/patchq/win-xennet-64/xennet.inspur.signed.tar",
-        "xeniface": r"win-xeniface/patchq/win-xeniface-61/xeniface.inspur.signed.tar",
-        "xenvbd": r"win-xenvbd/patchq/win-xenvbd-156/xenvbd.inspur.signed.tar", 
+        "xeniface": r"win-xeniface/patchq/win-xeniface-102/xeniface.signed.tar",
+        "xenvbd": r"win-xenvbd/patchq/win-xenvbd-158/xenvbd.signed.tar", 
         "xenvss" : r'win-xenvss/master/win-xenvss-18/xenvss.tar',
 }
 
 signed_drivers = {
-        "xenbus": r"win-xenbus/patchq-8.2/win-xenbus-113/xenbus.inspur.signed.tar",
-        "xenvif": r"win-xenvif/patchq/win-xenvif-103/xenvif.inspur.signed.tar",
-        "xennet": r"win-xennet/patchq/win-xennet-64/xennet.inspur.signed.tar",
-        "xeniface": r"win-xeniface/patchq/win-xeniface-61/xeniface.inspur.signed.tar",
-        "xenvbd": r"win-xenvbd/patchq/win-xenvbd-156/xenvbd.inspur.signed.tar", 
 }
 
 

--- a/manifestspecific.py
+++ b/manifestspecific.py
@@ -33,17 +33,17 @@ artifactory='https://repo.citrite.net:443/xs-local-build/'
 build_tar_source_files = {
        "xenguestagent" : r'win-xenguestagent/master/win-xenguestagent-218/xenguestagent.tar',
        "xenbus" : r'win-xenbus/patchq-8.2/win-xenbus-113/xenbus.signed.tar',
-       "xenvif" : r'win-xenvif/patchq/win-xenvif-103/xenvif.signed.tar',
+       "xenvif" : r'win-xenvif/patchq/win-xenvif-152/xenvif.signed.tar',
        "xennet" : r'win-xennet/patchq/win-xennet-64/xennet.signed.tar',
-       "xeniface" : r'win-xeniface/patchq/win-xeniface-61/xeniface.signed.tar',
+       "xeniface" : r'win-xeniface/patchq/win-xeniface-102/xeniface.signed.tar',
        "xenvbd" : r'win-xenvbd/patchq/win-xenvbd-157/xenvbd.tar',
        "xenvss" : r'win-xenvss/master/win-xenvss-18/xenvss.tar',
 }
 
 signed_drivers = { 
        "xenbus" : r'win-xenbus/patchq-8.2/win-xenbus-113/xenbus.signed.tar',
-       "xenvif" : r'win-xenvif/patchq/win-xenvif-103/xenvif.signed.tar',
+       "xenvif" : r'win-xenvif/patchq/win-xenvif-152/xenvif.signed.tar',
        "xennet" : r'win-xennet/patchq/win-xennet-64/xennet.signed.tar',
-       "xeniface" : r'win-xeniface/patchq/win-xeniface-61/xeniface.signed.tar',
-       "xenvbd" : r'win-xenvbd/patchq/win-xenvbd-156/xenvbd.signed.tar',
+       "xeniface" : r'win-xeniface/patchq/win-xeniface-102/xeniface.signed.tar',
+       "xenvbd" : r'win-xenvbd/patchq/win-xenvbd-158/xenvbd.signed.tar',
 }


### PR DESCRIPTION
UPD-108 : XENVIF 8.2.1.152
  CA-251602 : Xenbus monitor not removing reboot key
UPD-109 : XENIFACE 8.2.1.102
  CA-248924 : Excessive logging in windows after resuming from suspend
UPD-110 : XENVBD 8.2.1.158
  CA-237752 Windows 7 VM wedged in reboot loop (PdoReset loop)
  CA-257867 : SCTX-2567 : XENVBD caused VM hang